### PR TITLE
Add accessors to Rect attributes

### DIFF
--- a/geom.go
+++ b/geom.go
@@ -127,6 +127,31 @@ type Rect struct {
 	p, q Point // Enforced by NewRect: p[i] <= q[i] for all i.
 }
 
+// The coordinate of the point of the rectangle at i
+func (r *Rect) PointCoord(i int) float64 {
+  return r.p[i]
+}
+
+// The coordinate of the lengths of the rectangle at i
+func (r *Rect) LengthsCoord(i int) float64 {
+  return r.q[i] - r.p[i]
+}
+
+// Returns true if the two rectangles are equal
+func (r *Rect) Equal(other *Rect) bool {
+  for i, e := range r.p {
+    if e != other.p[i] {
+      return false
+    }
+  }
+  for i, e := range r.q {
+    if e != other.q[i] {
+      return false
+    }
+  }
+  return true
+}
+
 func (r *Rect) String() string {
 	s := make([]string, len(r.p))
 	for i, a := range r.p {

--- a/geom_test.go
+++ b/geom_test.go
@@ -55,6 +55,50 @@ func TestNewRectDistError(t *testing.T) {
 	}
 }
 
+func TestRectPointCoord(t *testing.T) {
+  p := Point{1.0, -2.5}
+  lengths := []float64{2.5, 8.0}
+  rect, _ := NewRect(p, lengths)
+
+  f := rect.PointCoord(0)
+  if f != 1.0 {
+    t.Errorf("Expected %v.PointCoord(0) == 1.0, got %v", rect, f)
+  }
+  f = rect.PointCoord(1)
+  if f != -2.5 {
+    t.Errorf("Expected %v.PointCoord(1) == -2.5, got %v", rect, f)
+  }
+}
+
+func TestRectLengthsCoord(t *testing.T) {
+  p := Point{1.0, -2.5}
+  lengths := []float64{2.5, 8.0}
+  rect, _ := NewRect(p, lengths)
+
+  f := rect.LengthsCoord(0)
+  if f != 2.5 {
+    t.Errorf("Expected %v.LengthsCoord(0) == 2.5, got %v", rect, f)
+  }
+  f = rect.LengthsCoord(1)
+  if f != 8.0 {
+    t.Errorf("Expected %v.LengthsCoord(1) == 8.0, got %v", rect, f)
+  }
+}
+
+func TestRectEqual(t *testing.T) {
+  p := Point{1.0, -2.5, 3.0}
+  lengths := []float64{2.5, 8.0, 1.5}
+  a, _ := NewRect(p, lengths)
+  b, _ := NewRect(p, lengths)
+  c, _ := NewRect(Point{0.0, -2.5, 3.0}, lengths)
+  if !a.Equal(b) {
+    t.Errorf("Expected %v.Equal(%v) to return true", a, b)
+  }
+  if a.Equal(c) {
+    t.Errorf("Expected %v.Equal(%v) to return false", a, c)
+  }
+}
+
 func TestRectSize(t *testing.T) {
 	p := Point{1.0, -2.5, 3.0}
 	lengths := []float64{2.5, 8.0, 1.5}


### PR DESCRIPTION
Hi Daniel,

I have a need to compare the `Rect`s stored in a Rtree with another `Rect` in my application, so that I can avoid needless update of the Rtree when the contents are actually equal.
I'm aware that we want to make the `Rect`s immutable in order to maintain internal consistency within a Rtree, but it seems that it's also possible to for users to get the contents of a `Rect`, too. This pull request implements this by adding accessors/getters to the Rect's attributes while maintaining that the `Rect` remains immutable.
