### PR TITLE
Search result filtering

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,6 +123,19 @@ that touch the search rectangle.
 	// Get a slice of the objects in rt that are contained inside bb:
 	results = rt.SearchContained(bb)
 
+### Filters
+
+You can filter out values during searches by implementing the Filter interface.
+
+  type Filter interface {
+		Filter(results []Spatial, object Spatial) (refuse, abort bool)
+	}
+
+A filter for limiting results by result count is included in the package.
+
+	// maximum of three results will be returned
+  tree.SearchIntersect(bb, NewLimitFilter(3))
+
 Nearest-neighbor queries find the objects in a tree closest to a specified
 query point.
 

--- a/README.md
+++ b/README.md
@@ -110,18 +110,13 @@ corrupt the tree.
 
 Bounding-box and k-nearest-neighbors queries are supported.
 
-Bounding-box queries require a search `*Rect` argument and come in two flavors:
-containment search and intersection search.  The former returns all objects that
-fall strictly inside the search rectangle, while the latter returns all objects
-that touch the search rectangle.
+Bounding-box queries require a search `*Rect`. It returns all objects that
+touch the search rectangle.
 
 	bb, _ := rtreego.NewRect(rtreego.Point{1.7, -3.4}, []float64{3.2, 1.9})
 
 	// Get a slice of the objects in rt that intersect bb:
 	results := rt.SearchIntersect(bb)
-
-	// Get a slice of the objects in rt that are contained inside bb:
-	results = rt.SearchContained(bb)
 
 ### Filters
 

--- a/README.md
+++ b/README.md
@@ -40,66 +40,66 @@ Documentation
 To create a new tree, specify the number of spatial dimensions and the minimum
 and maximum branching factor:
 
-	rt := rtreego.NewTree(2, 25, 50)
+  rt := rtreego.NewTree(2, 25, 50)
 
 Any type that implements the `Spatial` interface can be stored in the tree:
 
-	type Spatial interface {
-		Bounds() *Rect
-	}
+  type Spatial interface {
+    Bounds() *Rect
+  }
 
 `Rect`s are data structures for representing spatial objects, while `Point`s
 represent spatial locations.  Creating `Point`s is easy--they're just slices
 of `float64`s:
 
-	p1 := rtreego.Point{0.4, 0.5}
-	p2 := rtreego.Point{6.2, -3.4}
+  p1 := rtreego.Point{0.4, 0.5}
+  p2 := rtreego.Point{6.2, -3.4}
 
 To create a `Rect`, specify a location and the lengths of the sides:
 
-	r1, _ := rtreego.NewRect(p1, []float64{1, 2})
-	r2, _ := rtreego.NewRect(p2, []float64{1.7, 2.7})
+  r1, _ := rtreego.NewRect(p1, []float64{1, 2})
+  r2, _ := rtreego.NewRect(p2, []float64{1.7, 2.7})
 
 To demonstrate, let's create and store some test data.
 
-	type Thing struct {
-		where *Rect
-		name string
-	}
+  type Thing struct {
+    where *Rect
+    name string
+  }
 
-	func (t *Thing) Bounds() *Rect {
-		return t.where
-	}
+  func (t *Thing) Bounds() *Rect {
+    return t.where
+  }
 
-	rt.Insert(&Thing{r1, "foo"})
-	rt.Insert(&Thing{r2, "bar"})
+  rt.Insert(&Thing{r1, "foo"})
+  rt.Insert(&Thing{r2, "bar"})
 
-	size := rt.Size() // returns 2
+  size := rt.Size() // returns 2
 
 We can insert and delete objects from the tree in any order.
 
-	rt.Delete(thing2)
-	// do some stuff...
-	rt.Insert(anotherThing)
+  rt.Delete(thing2)
+  // do some stuff...
+  rt.Insert(anotherThing)
 
 If you want to store points instead of rectangles, you can easily convert a
 point into a rectangle using the `ToRect` method:
 
-	var tol = 0.01
+  var tol = 0.01
 
-	type Somewhere struct {
-		location rtreego.Point
-		name string
-		wormhole chan int
-	}
+  type Somewhere struct {
+    location rtreego.Point
+    name string
+    wormhole chan int
+  }
 
-	func (s *Somewhere) Bounds() *Rect {
-		// define the bounds of s to be a rectangle centered at s.location
-		// with side lengths 2 * tol:
-		return s.location.ToRect(tol)
-	}
+  func (s *Somewhere) Bounds() *Rect {
+    // define the bounds of s to be a rectangle centered at s.location
+    // with side lengths 2 * tol:
+    return s.location.ToRect(tol)
+  }
 
-	rt.Insert(&Somewhere{rtreego.Point{0, 0}, "Someplace", nil})
+  rt.Insert(&Somewhere{rtreego.Point{0, 0}, "Someplace", nil})
 
 If you want to update the location of an object, you must delete it, update it,
 and re-insert.  Just modifying the object so that the `*Rect` returned by
@@ -113,32 +113,32 @@ Bounding-box and k-nearest-neighbors queries are supported.
 Bounding-box queries require a search `*Rect`. It returns all objects that
 touch the search rectangle.
 
-	bb, _ := rtreego.NewRect(rtreego.Point{1.7, -3.4}, []float64{3.2, 1.9})
+  bb, _ := rtreego.NewRect(rtreego.Point{1.7, -3.4}, []float64{3.2, 1.9})
 
-	// Get a slice of the objects in rt that intersect bb:
-	results := rt.SearchIntersect(bb)
+  // Get a slice of the objects in rt that intersect bb:
+  results := rt.SearchIntersect(bb)
 
 ### Filters
 
 You can filter out values during searches by implementing the Filter interface.
 
   type Filter interface {
-		Filter(results []Spatial, object Spatial) (refuse, abort bool)
-	}
+    Filter(results []Spatial, object Spatial) (refuse, abort bool)
+  }
 
 A filter for limiting results by result count is included in the package.
 
-	// maximum of three results will be returned
+  // maximum of three results will be returned
   tree.SearchIntersect(bb, NewLimitFilter(3))
 
 Nearest-neighbor queries find the objects in a tree closest to a specified
 query point.
 
-	q := rtreego.Point{6.5, -2.47}
-	k := 5
+  q := rtreego.Point{6.5, -2.47}
+  k := 5
 
-	// Get a slice of the k objects in rt closest to q:
-	results = rt.SearchNearestNeighbors(q, k)
+  // Get a slice of the k objects in rt closest to q:
+  results = rt.SearchNearestNeighbors(q, k)
 
 ### More information
 

--- a/filter.go
+++ b/filter.go
@@ -1,0 +1,55 @@
+package rtreego
+
+// Filter is an interface for filtering leaves during search. The parameters
+// should be treated as read-only. If refuse is true, the currenty entry will
+// not be added to the result set. If abort is true, the search is aborted and
+// the current result set will be returned.
+type Filter interface {
+	Filter(results []Spatial, object Spatial) (refuse, abort bool)
+}
+
+// ApplyFilters applies the given filters and returns their consensus.
+func applyFilters(results []Spatial, object Spatial, filters []Filter) (bool, bool) {
+	var refuse, abort bool
+	for _, f := range filters {
+		ref, abt := f.Filter(results, object)
+
+		if ref {
+			refuse = true
+		}
+
+		if abt {
+			abort = true
+		}
+
+		// some filter after the aborting filter might still refuse the leaf,
+		// so we can only break early if both are true
+		if refuse && abort {
+			break
+		}
+	}
+
+	return refuse, abort
+}
+
+// LimitFilter aborts the search after certain amount of results have been
+// gathered.
+type LimitFilter struct {
+	limit int
+}
+
+// NewLimitFilter returns a new limit filter.
+func NewLimitFilter(limit int) *LimitFilter {
+	return &LimitFilter{
+		limit: limit,
+	}
+}
+
+// Filter checks if the results have reached the limit size and aborts if so.
+func (f *LimitFilter) Filter(results []Spatial, object Spatial) (bool, bool) {
+	if len(results) >= f.limit {
+		return true, true
+	}
+
+	return false, false
+}

--- a/filter.go
+++ b/filter.go
@@ -4,15 +4,13 @@ package rtreego
 // should be treated as read-only. If refuse is true, the currenty entry will
 // not be added to the result set. If abort is true, the search is aborted and
 // the current result set will be returned.
-type Filter interface {
-	Filter(results []Spatial, object Spatial) (refuse, abort bool)
-}
+type Filter func(results []Spatial, object Spatial) (refuse, abort bool)
 
 // ApplyFilters applies the given filters and returns their consensus.
 func applyFilters(results []Spatial, object Spatial, filters []Filter) (bool, bool) {
 	var refuse, abort bool
-	for _, f := range filters {
-		ref, abt := f.Filter(results, object)
+	for _, filter := range filters {
+		ref, abt := filter(results, object)
 
 		if ref {
 			refuse = true
@@ -32,24 +30,13 @@ func applyFilters(results []Spatial, object Spatial, filters []Filter) (bool, bo
 	return refuse, abort
 }
 
-// LimitFilter aborts the search after certain amount of results have been
-// gathered.
-type LimitFilter struct {
-	limit int
-}
+// LimitFilter checks if the results have reached the limit size and aborts if so.
+func LimitFilter(limit int) Filter {
+	return func(results []Spatial, object Spatial) (refuse, abort bool) {
+		if len(results) >= limit {
+			return true, true
+		}
 
-// NewLimitFilter returns a new limit filter.
-func NewLimitFilter(limit int) *LimitFilter {
-	return &LimitFilter{
-		limit: limit,
+		return false, false
 	}
-}
-
-// Filter checks if the results have reached the limit size and aborts if so.
-func (f *LimitFilter) Filter(results []Spatial, object Spatial) (bool, bool) {
-	if len(results) >= f.limit {
-		return true, true
-	}
-
-	return false, false
 }

--- a/geom.go
+++ b/geom.go
@@ -127,17 +127,17 @@ type Rect struct {
 	p, q Point // Enforced by NewRect: p[i] <= q[i] for all i.
 }
 
-// The coordinate of the point of the rectangle at i
+// PointCoord returns the coordinate of the point of the rectangle at i
 func (r *Rect) PointCoord(i int) float64 {
 	return r.p[i]
 }
 
-// The coordinate of the lengths of the rectangle at i
+// LengthsCoord returns the coordinate of the lengths of the rectangle at i
 func (r *Rect) LengthsCoord(i int) float64 {
 	return r.q[i] - r.p[i]
 }
 
-// Returns true if the two rectangles are equal
+// Equal returns true if the two rectangles are equal
 func (r *Rect) Equal(other *Rect) bool {
 	for i, e := range r.p {
 		if e != other.p[i] {
@@ -228,13 +228,13 @@ func (r *Rect) containsPoint(p Point) bool {
 }
 
 // containsRect tests whether r2 is is located inside r1.
-func (r1 *Rect) containsRect(r2 *Rect) bool {
-	if len(r1.p) != len(r2.p) {
-		panic(DimError{len(r1.p), len(r2.p)})
+func (r *Rect) containsRect(r2 *Rect) bool {
+	if len(r.p) != len(r2.p) {
+		panic(DimError{len(r.p), len(r2.p)})
 	}
 
-	for i, a1 := range r1.p {
-		b1, a2, b2 := r1.q[i], r2.p[i], r2.q[i]
+	for i, a1 := range r.p {
+		b1, a2, b2 := r.q[i], r2.p[i], r2.q[i]
 		// enforced by constructor: a1 <= b1 and a2 <= b2.
 		// so containment holds if and only if a1 <= a2 <= b2 <= b1
 		// for every dimension.

--- a/rtree.go
+++ b/rtree.go
@@ -74,7 +74,7 @@ func (e entry) String() string {
 	return fmt.Sprintf("entry{bb: %v, obj: %v}", e.bb, e.obj)
 }
 
-// Any type that implements Spatial can be stored in an Rtree and queried.
+// Spatial is an interface for objects that can be stored in an Rtree and queried.
 type Spatial interface {
 	Bounds() *Rect
 }
@@ -540,6 +540,7 @@ func (tree *Rtree) nearestNeighbor(p Point, n *node, d float64, nearest Spatial)
 	return nearest, d
 }
 
+// NearestNeighbors gets the closest Spatials to the Point.
 func (tree *Rtree) NearestNeighbors(k int, p Point) []Spatial {
 	dists := make([]float64, k)
 	objs := make([]Spatial, k)

--- a/rtree.go
+++ b/rtree.go
@@ -435,7 +435,7 @@ func (tree *Rtree) SearchIntersectWithLimit(k int, bb *Rect) []Spatial {
 	if k < 0 {
 		return tree.SearchIntersect(bb)
 	}
-	return tree.SearchIntersect(bb, NewLimitFilter(k))
+	return tree.SearchIntersect(bb, LimitFilter(k))
 }
 
 func (tree *Rtree) searchIntersect(results []Spatial, n *node, bb *Rect, filters []Filter) []Spatial {

--- a/rtree_test.go
+++ b/rtree_test.go
@@ -36,7 +36,7 @@ func printEntry(e entry, level int) {
 	if e.child != nil {
 		printNode(e.child, level)
 	} else {
-		fmt.Printf("%sObject: %p\n", padding, e.obj)
+		fmt.Printf("%sObject: %v\n", padding, e.obj)
 	}
 	fmt.Println()
 }

--- a/rtree_test.go
+++ b/rtree_test.go
@@ -3,6 +3,7 @@ package rtreego
 import (
 	"fmt"
 	"math/rand"
+	"reflect"
 	"strings"
 	"testing"
 )
@@ -758,6 +759,63 @@ func TestSearchIntersectWithLimit(t *testing.T) {
 				t.Errorf("SearchIntersect failed to find things[%d] for k = %d", ind, k)
 			}
 		}
+	}
+}
+
+func TestSearchIntersectWithTestFilter(t *testing.T) {
+	rt := NewTree(2, 3, 3)
+	things := []*Rect{
+		mustRect(Point{0, 0}, []float64{2, 1}),
+		mustRect(Point{3, 1}, []float64{1, 2}),
+		mustRect(Point{1, 2}, []float64{2, 2}),
+		mustRect(Point{8, 6}, []float64{1, 1}),
+		mustRect(Point{10, 3}, []float64{1, 2}),
+		mustRect(Point{11, 7}, []float64{1, 1}),
+		mustRect(Point{2, 6}, []float64{1, 2}),
+		mustRect(Point{3, 6}, []float64{1, 2}),
+		mustRect(Point{2, 8}, []float64{1, 2}),
+		mustRect(Point{3, 8}, []float64{1, 2}),
+	}
+	for _, thing := range things {
+		rt.Insert(thing)
+	}
+
+	bb := mustRect(Point{2, 1.5}, []float64{10, 5.5})
+
+	// intersecting indexes are 1, 2, 6, 7, 3, 4
+	// rects which we do not filter out
+	expected := []int{1, 6, 4}
+
+	// this test filter will only pick the objects that match the specified indexes
+	// in things
+	objects := rt.SearchIntersect(bb, func(results []Spatial, object Spatial) (bool, bool) {
+		rect := object.(*Rect)
+
+		for _, a := range expected {
+			if rect == things[a] {
+				return false, false
+			}
+		}
+
+		return true, false
+	})
+
+	if len(expected) != len(objects) {
+		t.Fatalf("expected %d results but received %d:", len(expected), len(objects))
+	}
+
+	actual := make([]int, 3)
+	for _, obj := range objects {
+		rect := obj.(*Rect)
+		for i := range things {
+			if rect == things[i] {
+				actual = append(actual, i)
+			}
+		}
+	}
+
+	if reflect.DeepEqual(actual, expected) {
+		t.Errorf("expected results: %v, actual results: %v", expected, actual)
 	}
 }
 


### PR DESCRIPTION
Adds support for filtering results of the search. Addresses a use case where I want to search for objects in the tree in a specified area with specified characteristics with a specified amount of results. Doing the filtering while searching prevents problems like asking for 100 results but after filtering the returned results, only having 45 viable results at hand.

Also removes documentation about SearchContained function which seems to be missing. 