### PR TITLE
NearestNeighbors prunes too much

### DIFF
--- a/rtree.go
+++ b/rtree.go
@@ -593,18 +593,16 @@ func insertNearest(k int, dists []float64, nearest []Spatial, dist float64, obj 
 	}
 
 	left, right := dists[:i], dists[i:len(dists)-1]
-	updatedDists := make([]float64, len(dists))
-	copy(updatedDists, left)
-	updatedDists[i] = dist
-	copy(updatedDists[i+1:], right)
+	copy(dists, left)
+	copy(dists[i+1:], right)
+	dists[i] = dist
 
 	leftObjs, rightObjs := nearest[:i], nearest[i:len(nearest)-1]
-	updatedNearest := make([]Spatial, len(nearest))
-	copy(updatedNearest, leftObjs)
-	updatedNearest[i] = obj
-	copy(updatedNearest[i+1:], rightObjs)
+	copy(nearest, leftObjs)
+	copy(nearest[i+1:], rightObjs)
+	nearest[i] = obj
 
-	return updatedDists, updatedNearest
+	return dists, nearest
 }
 
 func (tree *Rtree) nearestNeighbors(k int, p Point, n *node, dists []float64, nearest []Spatial) ([]Spatial, []float64) {

--- a/rtree.go
+++ b/rtree.go
@@ -577,7 +577,7 @@ func (tree *Rtree) NearestNeighbors(k int, p Point) []Spatial {
 
 // insert obj into nearest and return the first k elements in increasing order.
 func insertNearest(k int, dists []float64, nearest []Spatial, dist float64, obj Spatial) ([]float64, []Spatial) {
-	i := 0
+	i := sort.SearchFloat64s(dists, dist)
 	for i < len(nearest) && dist >= dists[i] {
 		i++
 	}

--- a/rtree.go
+++ b/rtree.go
@@ -535,13 +535,13 @@ func pruneEntries(p Point, entries []entry, minDists []float64) []entry {
 }
 
 func pruneEntriesMinDist(d float64, entries []entry, minDists []float64) []entry {
-	pruned := []entry{}
-	for i := range entries {
-		if minDists[i] <= d {
-			pruned = append(pruned, entries[i])
+	var i int
+	for ; i < len(entries); i++ {
+		if minDists[i] > d {
+			break
 		}
 	}
-	return pruned
+	return entries[:i]
 }
 
 func (tree *Rtree) nearestNeighbor(p Point, n *node, d float64, nearest Spatial) (Spatial, float64) {

--- a/rtree.go
+++ b/rtree.go
@@ -491,7 +491,6 @@ func (tree *Rtree) NearestNeighbor(p Point) Spatial {
 type entrySlice struct {
 	entries []entry
 	dists   []float64
-	pt      Point
 }
 
 func (s entrySlice) Len() int { return len(s.entries) }
@@ -512,7 +511,7 @@ func sortEntries(p Point, entries []entry) ([]entry, []float64) {
 		sorted[i] = entries[i]
 		dists[i] = p.minDist(entries[i].bb)
 	}
-	sort.Sort(entrySlice{sorted, dists, p})
+	sort.Sort(entrySlice{sorted, dists})
 	return sorted, dists
 }
 
@@ -613,8 +612,8 @@ func (tree *Rtree) nearestNeighbors(k int, p Point, n *node, dists []float64, ne
 		}
 	} else {
 		branches, branchDists := sortEntries(p, n.entries)
-		// only prune if some element in buffer
-		if l := len(dists); l == k {
+		// only prune if buffer has k elements
+		if l := len(dists); l >= k {
 			branches = pruneEntriesMinDist(dists[l-1], branches, branchDists)
 		}
 		for _, e := range branches {


### PR DESCRIPTION
The current implementation of NearestNeighbors is pruning too early branches. That results in incorrect searches. For example, if the tree contains N entries and one searches for N entries, the search will return less than N, although it would have enough entries to fulfill the request.

This pull request introduces 3 main changes to the prune strategy. The search prunes 
- the branches based on the furthest node in the buffer (dists and nearest)
- using minDist instead of minMaxDist and
- only after k nodes are in the buffer.

This approach follows what is actually described here in [Enhanced Nearest Neighbour Search on the R-tree](https://pdfs.semanticscholar.org/92b8/45459f6a64a79addd2b46efc6c99c4f6b264.pdf).

The PR also changes the NearestNeighbors test case to reveal the issue above and does some performance improvement in insertNearest by removing unnecessary allocations.
