### PR TITLE
NearestNeighbors filters & OMT bulk-loading

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,1 +1,4 @@
 language: go
+
+before_install:
+  - go get github.com/facebookgo/ensure

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,1 @@
 language: go
-
-before_install:
-  - go get github.com/facebookgo/ensure

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ About
 
 The R-tree is a popular data structure for efficiently storing and
 querying spatial objects; one common use is implementing geospatial
-indexes in database management systems.  Both bounding-box queries
+indexes in database management systems. Both bounding-box queries
 and k-nearest-neighbor queries are supported.
 
 R-trees are balanced, so maximum tree height is guaranteed to be
@@ -41,6 +41,11 @@ To create a new tree, specify the number of spatial dimensions and the minimum
 and maximum branching factor:
 
     rt := rtreego.NewTree(2, 25, 50)
+
+You can also bulk-load the tree when creating it by passing the objects as
+a parameter.
+
+    rt := rtreego.NewTree(2, 25, 50, objects...)
 
 Any type that implements the `Spatial` interface can be stored in the tree:
 

--- a/rtree.go
+++ b/rtree.go
@@ -30,15 +30,31 @@ type Rtree struct {
 	height      int
 }
 
-// NewTree creates a new R-tree instance.
-func NewTree(Dim, MinChildren, MaxChildren int) *Rtree {
-	rt := Rtree{Dim: Dim, MinChildren: MinChildren, MaxChildren: MaxChildren}
-	rt.height = 1
-	rt.root = &node{}
-	rt.root.entries = []entry{}
-	rt.root.leaf = true
-	rt.root.level = 1
-	return &rt
+// NewTree returns an Rtree. If the number of objects given on initialization
+// is larger than max, the Rtree will be initialized using the Overlap
+// Minimizing Top-down bulk-loading algorithm.
+func NewTree(dim, min, max int, objs ...Spatial) *Rtree {
+	rt := &Rtree{
+		Dim:         dim,
+		MinChildren: min,
+		MaxChildren: max,
+		height:      1,
+		root: &node{
+			entries: []entry{},
+			leaf:    true,
+			level:   1,
+		},
+	}
+
+	if len(objs) <= rt.MaxChildren {
+		for _, obj := range objs {
+			rt.Insert(obj)
+		}
+	} else {
+		rt.bulkLoad(objs)
+	}
+
+	return rt
 }
 
 // Size returns the number of objects currently stored in tree.
@@ -53,6 +69,145 @@ func (tree *Rtree) String() string {
 // Depth returns the maximum depth of tree.
 func (tree *Rtree) Depth() int {
 	return tree.height
+}
+
+type dimSorter struct {
+	dim  int
+	objs []entry
+}
+
+func (s *dimSorter) Len() int {
+	return len(s.objs)
+}
+
+func (s *dimSorter) Swap(i, j int) {
+	s.objs[i], s.objs[j] = s.objs[j], s.objs[i]
+}
+
+func (s *dimSorter) Less(i, j int) bool {
+	return s.objs[i].bb.p[s.dim] < s.objs[j].bb.p[s.dim]
+}
+
+// splitByM splits objects into slices of maximum m elements.
+// Split 10 in to 3 will yield 3 + 3 + 3 + 1
+func splitByM(m int, objs []entry) [][]entry {
+	perSlice := len(objs) / m
+
+	numSlices := m
+	if len(objs)%m != 0 {
+		numSlices++
+	}
+
+	split := make([][]entry, numSlices)
+	for i := 0; i < numSlices; i++ {
+		if i == numSlices-1 {
+			split[i] = objs[i*perSlice:]
+			break
+		}
+
+		split[i] = objs[i*perSlice : i*perSlice+perSlice]
+	}
+
+	return split
+}
+
+// splitInS splits objects into s slices and puts the left over elements in the
+// last slice.
+// Split 10 in to 3 will yield 3 + 3 + 4
+func splitInS(s int, objs []entry) [][]entry {
+	split := splitByM(s, objs)
+	if len(split) < 2 {
+		return split
+	}
+
+	last := split[len(split)-1]
+	secondLast := split[len(split)-2]
+
+	if len(last) < len(secondLast) {
+		merged := append(secondLast, last...)
+		split = split[:len(split)-1]
+		split[len(split)-1] = merged
+	}
+
+	return split
+}
+
+func sortByDim(dim int, objs []entry) {
+	sort.Sort(&dimSorter{dim, objs})
+}
+
+// bulkLoad bulk loads the Rtree using OMT algorithm. bulkLoad contains special
+// handling for the root node.
+func (tree *Rtree) bulkLoad(objs []Spatial) {
+	n := len(objs)
+
+	// create entries for all the objects
+	entries := make([]entry, n)
+	for i := range objs {
+		entries[i] = entry{
+			bb:  objs[i].Bounds(),
+			obj: objs[i],
+		}
+	}
+
+	// root will never be a leaf in the bulk-loaded tree
+	tree.root.leaf = false
+	tree.size = n
+	// following equations are defined in the paper describing OMT
+	tree.height = int(math.Ceil(math.Log(float64(n)) / float64(math.Log(float64(tree.MaxChildren)))))
+	tree.root.level = tree.height
+	nsub := int(math.Pow(float64(tree.MaxChildren), float64(tree.height-1)))
+	s := int(math.Floor(math.Sqrt(math.Ceil(float64(n) / float64(nsub)))))
+
+	sortByDim(0, entries)
+
+	// we can preallocate entries here as we know the root will always be
+	// split into s groups
+	tree.root.entries = make([]entry, s)
+
+	// build the root first as we have to split it differently from the subtrees
+	for i, part := range splitInS(s, entries) {
+		child := tree.omt(tree.root.level-1, part, tree.MaxChildren)
+		child.parent = tree.root
+
+		tree.root.entries[i].bb = child.computeBoundingBox()
+		tree.root.entries[i].child = child
+	}
+}
+
+// omt the is the recursive part of the Overlap Minimizing Top-loading bulk-
+// load approach. Returns the root node of a subtree.
+func (tree *Rtree) omt(level int, objs []entry, m int) *node {
+	// if number of objects is less than or equal than max children per leaf,
+	// we need to create a leaf node
+	if len(objs) <= m {
+		return &node{
+			leaf:    true,
+			entries: objs,
+			level:   level,
+		}
+	}
+
+	// sort the tree on every level by a different dimension than the previous
+	// level, this will prevent overlapping of the branches
+	sortByDim((tree.height-level)%tree.Dim, objs)
+
+	n := &node{
+		level:   level,
+		entries: make([]entry, 0, m),
+	}
+
+	for _, part := range splitByM(m, objs) {
+		child := tree.omt(level-1, part, m)
+		child.parent = n
+
+		n.entries = append(n.entries, entry{
+			bb:    child.computeBoundingBox(),
+			child: child,
+		})
+	}
+
+	return n
 }
 
 // node represents a tree node of an Rtree.

--- a/rtree_test.go
+++ b/rtree_test.go
@@ -4,11 +4,38 @@ import (
 	"fmt"
 	"log"
 	"math/rand"
-	"reflect"
 	"sort"
 	"strings"
 	"testing"
+
+	"github.com/facebookgo/ensure"
 )
+
+type testCase struct {
+	name string
+	tree *Rtree
+}
+
+func tests(dim, min, max int, objs ...Spatial) []*testCase {
+	return []*testCase{
+		{
+			"dynamically built",
+			func() *Rtree {
+				rt := NewTree(dim, min, max)
+				for _, thing := range objs {
+					rt.Insert(thing)
+				}
+				return rt
+			}(),
+		},
+		{
+			"bulk-loaded",
+			func() *Rtree {
+				return NewTree(dim, min, max, objs...)
+			}(),
+		},
+	}
+}
 
 func (r *Rect) Bounds() *Rect {
 	return r
@@ -349,10 +376,16 @@ func TestAdjustTreeSplitParent(t *testing.T) {
 }
 
 func TestInsertRepeated(t *testing.T) {
-	rt := NewTree(2, 3, 5)
-	thing := mustRect(Point{0, 0}, []float64{2, 1})
-	for i := 0; i < 6; i++ {
-		rt.Insert(thing)
+	var things []Spatial
+	for i := 0; i < 10; i++ {
+		things = append(things, mustRect(Point{0, 0}, []float64{2, 1}))
+	}
+
+	for _, tc := range tests(2, 3, 5, things...) {
+		t.Run(tc.name, func(t *testing.T) {
+			rt := tc.tree
+			rt.Insert(mustRect(Point{0, 0}, []float64{2, 1}))
+		})
 	}
 }
 
@@ -630,23 +663,23 @@ func TestInsertNonLeaf(t *testing.T) {
 }
 
 func TestDeleteFlatten(t *testing.T) {
-	rt := NewTree(2, 3, 3)
-	things := []*Rect{
+	things := []Spatial{
 		mustRect(Point{0, 0}, []float64{2, 1}),
 		mustRect(Point{3, 1}, []float64{1, 2}),
 	}
-	for _, thing := range things {
-		rt.Insert(thing)
-	}
 
-	// make sure flattening didn't nuke the tree
-	rt.Delete(things[0])
-	verify(t, rt.root)
+	for _, tc := range tests(2, 3, 3, things...) {
+		t.Run(tc.name, func(t *testing.T) {
+			rt := tc.tree
+			// make sure flattening didn't nuke the tree
+			rt.Delete(things[0])
+			verify(t, rt.root)
+		})
+	}
 }
 
 func TestDelete(t *testing.T) {
-	rt := NewTree(2, 3, 3)
-	things := []*Rect{
+	things := []Spatial{
 		mustRect(Point{0, 0}, []float64{2, 1}),
 		mustRect(Point{3, 1}, []float64{1, 2}),
 		mustRect(Point{1, 2}, []float64{2, 2}),
@@ -658,31 +691,34 @@ func TestDelete(t *testing.T) {
 		mustRect(Point{0, 8}, []float64{1, 2}),
 		mustRect(Point{1, 8}, []float64{1, 2}),
 	}
-	for _, thing := range things {
-		rt.Insert(thing)
-	}
 
-	verify(t, rt.root)
+	for _, tc := range tests(2, 3, 3, things...) {
+		t.Run(tc.name, func(t *testing.T) {
+			rt := tc.tree
 
-	things2 := []*Rect{}
-	for len(things) > 0 {
-		i := rand.Int() % len(things)
-		things2 = append(things2, things[i])
-		things = append(things[:i], things[i+1:]...)
-	}
+			verify(t, rt.root)
 
-	for i, thing := range things2 {
-		ok := rt.Delete(thing)
-		if !ok {
-			t.Errorf("Thing %v was not found in tree during deletion", thing)
-			return
-		}
+			things2 := []Spatial{}
+			for len(things) > 0 {
+				i := rand.Int() % len(things)
+				things2 = append(things2, things[i])
+				things = append(things[:i], things[i+1:]...)
+			}
 
-		if rt.Size() != len(things2)-i-1 {
-			t.Errorf("Delete failed to remove %v", thing)
-			return
-		}
-		verify(t, rt.root)
+			for i, thing := range things2 {
+				ok := rt.Delete(thing)
+				if !ok {
+					t.Errorf("Thing %v was not found in tree during deletion", thing)
+					return
+				}
+
+				if rt.Size() != len(things2)-i-1 {
+					t.Errorf("Delete failed to remove %v", thing)
+					return
+				}
+				//				verify(t, rt.root)
+			}
+		})
 	}
 }
 
@@ -709,69 +745,69 @@ func TestDeleteWithDepthChange(t *testing.T) {
 }
 
 func TestDeleteWithComparator(t *testing.T) {
-	rt := NewTree(2, 3, 3)
-
 	type IDRect struct {
 		ID string
 		*Rect
 	}
 
-	things := []*IDRect{
-		{"1", mustRect(Point{0, 0}, []float64{2, 1})},
-		{"2", mustRect(Point{3, 1}, []float64{1, 2})},
-		{"3", mustRect(Point{1, 2}, []float64{2, 2})},
-		{"4", mustRect(Point{8, 6}, []float64{1, 1})},
-		{"5", mustRect(Point{10, 3}, []float64{1, 2})},
-		{"6", mustRect(Point{11, 7}, []float64{1, 1})},
-		{"7", mustRect(Point{0, 6}, []float64{1, 2})},
-		{"8", mustRect(Point{1, 6}, []float64{1, 2})},
-		{"9", mustRect(Point{0, 8}, []float64{1, 2})},
-		{"10", mustRect(Point{1, 8}, []float64{1, 2})},
-	}
-	for _, thing := range things {
-		rt.Insert(thing)
+	things := []Spatial{
+		&IDRect{"1", mustRect(Point{0, 0}, []float64{2, 1})},
+		&IDRect{"2", mustRect(Point{3, 1}, []float64{1, 2})},
+		&IDRect{"3", mustRect(Point{1, 2}, []float64{2, 2})},
+		&IDRect{"4", mustRect(Point{8, 6}, []float64{1, 1})},
+		&IDRect{"5", mustRect(Point{10, 3}, []float64{1, 2})},
+		&IDRect{"6", mustRect(Point{11, 7}, []float64{1, 1})},
+		&IDRect{"7", mustRect(Point{0, 6}, []float64{1, 2})},
+		&IDRect{"8", mustRect(Point{1, 6}, []float64{1, 2})},
+		&IDRect{"9", mustRect(Point{0, 8}, []float64{1, 2})},
+		&IDRect{"10", mustRect(Point{1, 8}, []float64{1, 2})},
 	}
 
-	verify(t, rt.root)
+	for _, tc := range tests(2, 3, 3, things...) {
+		t.Run(tc.name, func(t *testing.T) {
+			rt := tc.tree
 
-	cmp := func(obj1, obj2 Spatial) bool {
-		idr1 := obj1.(*IDRect)
-		idr2 := obj2.(*IDRect)
-		return idr1.ID == idr2.ID
-	}
+			verify(t, rt.root)
 
-	things2 := []*IDRect{}
-	for len(things) > 0 {
-		i := rand.Int() % len(things)
-		// make a deep copy
-		copy := &IDRect{things[i].ID, &(*things[i].Rect)}
-		things2 = append(things2, copy)
+			cmp := func(obj1, obj2 Spatial) bool {
+				idr1 := obj1.(*IDRect)
+				idr2 := obj2.(*IDRect)
+				return idr1.ID == idr2.ID
+			}
 
-		if !cmp(things[i], copy) {
-			log.Fatalf("expected copy to be equal to the original, original: %v, copy: %v", things[i], copy)
-		}
+			things2 := []*IDRect{}
+			for len(things) > 0 {
+				i := rand.Int() % len(things)
+				// make a deep copy
+				copy := &IDRect{things[i].(*IDRect).ID, &(*things[i].(*IDRect).Rect)}
+				things2 = append(things2, copy)
 
-		things = append(things[:i], things[i+1:]...)
-	}
+				if !cmp(things[i], copy) {
+					log.Fatalf("expected copy to be equal to the original, original: %v, copy: %v", things[i], copy)
+				}
 
-	for i, thing := range things2 {
-		ok := rt.DeleteWithComparator(thing, cmp)
-		if !ok {
-			t.Errorf("Thing %v was not found in tree during deletion", thing)
-			return
-		}
+				things = append(things[:i], things[i+1:]...)
+			}
 
-		if rt.Size() != len(things2)-i-1 {
-			t.Errorf("Delete failed to remove %v", thing)
-			return
-		}
-		verify(t, rt.root)
+			for i, thing := range things2 {
+				ok := rt.DeleteWithComparator(thing, cmp)
+				if !ok {
+					t.Errorf("Thing %v was not found in tree during deletion", thing)
+					return
+				}
+
+				if rt.Size() != len(things2)-i-1 {
+					t.Errorf("Delete failed to remove %v", thing)
+					return
+				}
+				verify(t, rt.root)
+			}
+		})
 	}
 }
 
 func TestSearchIntersect(t *testing.T) {
-	rt := NewTree(2, 3, 3)
-	things := []*Rect{
+	things := []Spatial{
 		mustRect(Point{0, 0}, []float64{2, 1}),
 		mustRect(Point{3, 1}, []float64{1, 2}),
 		mustRect(Point{1, 2}, []float64{2, 2}),
@@ -783,27 +819,27 @@ func TestSearchIntersect(t *testing.T) {
 		mustRect(Point{2, 8}, []float64{1, 2}),
 		mustRect(Point{3, 8}, []float64{1, 2}),
 	}
-	for _, thing := range things {
-		rt.Insert(thing)
+
+	for _, tc := range tests(2, 3, 3, things...) {
+		t.Run(tc.name, func(t *testing.T) {
+			rt := tc.tree
+
+			bb := mustRect(Point{2, 1.5}, []float64{10, 5.5})
+			q := rt.SearchIntersect(bb)
+
+			var expected []Spatial
+			for _, i := range []int{1, 2, 3, 4, 6, 7} {
+				expected = append(expected, things[i])
+			}
+
+			ensure.DisorderedSubset(t, q, expected)
+		})
 	}
 
-	bb := mustRect(Point{2, 1.5}, []float64{10, 5.5})
-	q := rt.SearchIntersect(bb)
-
-	expected := []int{1, 2, 3, 4, 6, 7}
-	if len(q) != len(expected) {
-		t.Errorf("SearchIntersect failed to find all objects")
-	}
-	for _, ind := range expected {
-		if indexOf(q, things[ind]) < 0 {
-			t.Errorf("SearchIntersect failed to find things[%d]", ind)
-		}
-	}
 }
 
 func TestSearchIntersectWithLimit(t *testing.T) {
-	rt := NewTree(2, 3, 3)
-	things := []*Rect{
+	things := []Spatial{
 		mustRect(Point{0, 0}, []float64{2, 1}),
 		mustRect(Point{3, 1}, []float64{1, 2}),
 		mustRect(Point{1, 2}, []float64{2, 2}),
@@ -815,41 +851,43 @@ func TestSearchIntersectWithLimit(t *testing.T) {
 		mustRect(Point{2, 8}, []float64{1, 2}),
 		mustRect(Point{3, 8}, []float64{1, 2}),
 	}
-	for _, thing := range things {
-		rt.Insert(thing)
-	}
 
-	bb := mustRect(Point{2, 1.5}, []float64{10, 5.5})
+	for _, tc := range tests(2, 3, 3, things...) {
+		t.Run(tc.name, func(t *testing.T) {
+			rt := tc.tree
 
-	// bbIntersects contains the indices of the rectangles that fall in
-	// the bounding box bb.
-	bbIntersects := []int{1, 2, 6, 7, 3, 4}
+			bb := mustRect(Point{2, 1.5}, []float64{10, 5.5})
 
-	// Loop through all possible limits k of SearchIntersectWithLimit,
-	// and test that the results are as expected.
-	for k := -1; k <= len(things); k++ {
-		q := rt.SearchIntersectWithLimit(k, bb)
-
-		expected := bbIntersects
-		if k >= 0 && k < len(bbIntersects) {
-			expected = bbIntersects[0:k]
-		}
-
-		if lq, le := len(q), len(expected); lq != le {
-			t.Errorf("Expected %d objects to be found, but found %d", le, lq)
-		}
-
-		for _, ind := range expected {
-			if indexOf(q, things[ind]) < 0 {
-				t.Errorf("SearchIntersect failed to find things[%d] for k = %d", ind, k)
+			// expected contains all the intersecting things
+			var expected []Spatial
+			for _, i := range []int{1, 2, 6, 7, 3, 4} {
+				expected = append(expected, things[i])
 			}
-		}
+
+			// Loop through all possible limits k of SearchIntersectWithLimit,
+			// and test that the results are as expected.
+			for k := -1; k <= len(things); k++ {
+				q := rt.SearchIntersectWithLimit(k, bb)
+
+				if k == -1 {
+					ensure.DisorderedSubset(t, expected, q)
+					ensure.True(t, len(q) == len(expected))
+				} else if k == 0 {
+					ensure.True(t, len(q) == 0)
+				} else if k <= len(expected) {
+					ensure.DisorderedSubset(t, expected, q)
+					ensure.True(t, len(q) == k, len(q))
+				} else {
+					ensure.DisorderedSubset(t, expected, q)
+					ensure.True(t, len(q) == len(expected))
+				}
+			}
+		})
 	}
 }
 
 func TestSearchIntersectWithTestFilter(t *testing.T) {
-	rt := NewTree(2, 3, 3)
-	things := []*Rect{
+	things := []Spatial{
 		mustRect(Point{0, 0}, []float64{2, 1}),
 		mustRect(Point{3, 1}, []float64{1, 2}),
 		mustRect(Point{1, 2}, []float64{2, 2}),
@@ -861,52 +899,37 @@ func TestSearchIntersectWithTestFilter(t *testing.T) {
 		mustRect(Point{2, 8}, []float64{1, 2}),
 		mustRect(Point{3, 8}, []float64{1, 2}),
 	}
-	for _, thing := range things {
-		rt.Insert(thing)
-	}
 
-	bb := mustRect(Point{2, 1.5}, []float64{10, 5.5})
+	for _, tc := range tests(2, 3, 3, things...) {
+		t.Run(tc.name, func(t *testing.T) {
+			rt := tc.tree
 
-	// intersecting indexes are 1, 2, 6, 7, 3, 4
-	// rects which we do not filter out
-	expected := []int{1, 6, 4}
+			bb := mustRect(Point{2, 1.5}, []float64{10, 5.5})
 
-	// this test filter will only pick the objects that match the specified indexes
-	// in things
-	objects := rt.SearchIntersect(bb, func(results []Spatial, object Spatial) (bool, bool) {
-		rect := object.(*Rect)
-
-		for _, a := range expected {
-			if rect == things[a] {
-				return false, false
+			// intersecting indexes are 1, 2, 6, 7, 3, 4
+			// rects which we do not filter out
+			var expected []Spatial
+			for _, i := range []int{1, 6, 4} {
+				expected = append(expected, things[i])
 			}
-		}
 
-		return true, false
-	})
+			// this test filter will only pick the objects that are in expected
+			objects := rt.SearchIntersect(bb, func(results []Spatial, object Spatial) (bool, bool) {
+				for _, exp := range expected {
+					if exp == object {
+						return false, false
+					}
+				}
+				return true, false
+			})
 
-	if len(expected) != len(objects) {
-		t.Fatalf("expected %d results but received %d:", len(expected), len(objects))
-	}
-
-	actual := make([]int, 3)
-	for _, obj := range objects {
-		rect := obj.(*Rect)
-		for i := range things {
-			if rect == things[i] {
-				actual = append(actual, i)
-			}
-		}
-	}
-
-	if reflect.DeepEqual(actual, expected) {
-		t.Errorf("expected results: %v, actual results: %v", expected, actual)
+			ensure.DisorderedSubset(t, objects, expected)
+		})
 	}
 }
 
 func TestSearchIntersectNoResults(t *testing.T) {
-	rt := NewTree(2, 3, 3)
-	things := []*Rect{
+	things := []Spatial{
 		mustRect(Point{0, 0}, []float64{2, 1}),
 		mustRect(Point{3, 1}, []float64{1, 2}),
 		mustRect(Point{1, 2}, []float64{2, 2}),
@@ -918,14 +941,17 @@ func TestSearchIntersectNoResults(t *testing.T) {
 		mustRect(Point{2, 8}, []float64{1, 2}),
 		mustRect(Point{3, 8}, []float64{1, 2}),
 	}
-	for _, thing := range things {
-		rt.Insert(thing)
-	}
 
-	bb := mustRect(Point{99, 99}, []float64{10, 5.5})
-	q := rt.SearchIntersect(bb)
-	if len(q) != 0 {
-		t.Errorf("SearchIntersect failed to return nil slice on failing query")
+	for _, tc := range tests(2, 3, 3, things...) {
+		t.Run(tc.name, func(t *testing.T) {
+			rt := tc.tree
+
+			bb := mustRect(Point{99, 99}, []float64{10, 5.5})
+			q := rt.SearchIntersect(bb)
+			if len(q) != 0 {
+				t.Errorf("SearchIntersect failed to return nil slice on failing query")
+			}
+		})
 	}
 }
 
@@ -949,8 +975,7 @@ func TestSortEntries(t *testing.T) {
 }
 
 func TestNearestNeighbor(t *testing.T) {
-	rt := NewTree(2, 3, 3)
-	things := []*Rect{
+	things := []Spatial{
 		mustRect(Point{1, 1}, []float64{1, 1}),
 		mustRect(Point{1, 3}, []float64{1, 1}),
 		mustRect(Point{3, 2}, []float64{1, 1}),
@@ -958,43 +983,42 @@ func TestNearestNeighbor(t *testing.T) {
 		mustRect(Point{7, 7}, []float64{1, 1}),
 		mustRect(Point{10, 2}, []float64{1, 1}),
 	}
-	for _, thing := range things {
-		rt.Insert(thing)
-	}
 
-	obj1 := rt.NearestNeighbor(Point{0.5, 0.5})
-	obj2 := rt.NearestNeighbor(Point{1.5, 4.5})
-	obj3 := rt.NearestNeighbor(Point{5, 2.5})
-	obj4 := rt.NearestNeighbor(Point{3.5, 2.5})
+	for _, tc := range tests(2, 3, 3, things...) {
+		t.Run(tc.name, func(t *testing.T) {
+			rt := tc.tree
 
-	if obj1 != things[0] || obj2 != things[1] || obj3 != things[2] || obj4 != things[2] {
-		t.Errorf("NearestNeighbor failed")
+			obj1 := rt.NearestNeighbor(Point{0.5, 0.5})
+			obj2 := rt.NearestNeighbor(Point{1.5, 4.5})
+			obj3 := rt.NearestNeighbor(Point{5, 2.5})
+			obj4 := rt.NearestNeighbor(Point{3.5, 2.5})
+
+			if obj1 != things[0] || obj2 != things[1] || obj3 != things[2] || obj4 != things[2] {
+				t.Errorf("NearestNeighbor failed")
+			}
+		})
 	}
 }
 
-type sortableRects struct {
-	r []*Rect
+type byMinDist struct {
+	r []Spatial
 	p Point
 }
 
-func (r sortableRects) Less(i, j int) bool {
-	if r.p.minDist(r.r[i]) < r.p.minDist(r.r[j]) {
-		return true
-	}
-	return false
+func (r byMinDist) Less(i, j int) bool {
+	return r.p.minDist(r.r[i].Bounds()) < r.p.minDist(r.r[j].Bounds())
 }
 
-func (r sortableRects) Len() int {
+func (r byMinDist) Len() int {
 	return len(r.r)
 }
 
-func (r sortableRects) Swap(i, j int) {
+func (r byMinDist) Swap(i, j int) {
 	r.r[i], r.r[j] = r.r[j], r.r[i]
 }
 
-func TestNearestNeighbors(t *testing.T) {
-	rt := NewTree(2, 3, 3)
-	things := []*Rect{
+func TestNearestNeighborsAll(t *testing.T) {
+	things := []Spatial{
 		mustRect(Point{1, 1}, []float64{1, 1}),
 		mustRect(Point{-7, -7}, []float64{1, 1}),
 		mustRect(Point{1, 3}, []float64{1, 1}),
@@ -1002,22 +1026,57 @@ func TestNearestNeighbors(t *testing.T) {
 		mustRect(Point{10, 2}, []float64{1, 1}),
 		mustRect(Point{3, 3}, []float64{1, 1}),
 	}
-	for _, thing := range things {
-		rt.Insert(thing)
+
+	for _, tc := range tests(2, 3, 3, things...) {
+		t.Run(tc.name, func(t *testing.T) {
+			rt := tc.tree
+
+			p := Point{0.5, 0.5}
+			sort.Sort(byMinDist{things, p})
+
+			objs := rt.NearestNeighbors(len(things), p)
+			for i := range things {
+				if objs[i] != things[i] {
+					t.Errorf("NearestNeighbors failed at index %d: %v != %v", i, objs[i], things[i])
+				}
+			}
+
+			objs = rt.NearestNeighbors(len(things)+2, p)
+			if len(objs) > len(things) {
+				t.Errorf("NearestNeighbors failed: too many elements")
+			}
+		})
+	}
+}
+
+func TestNearestNeighborsHalf(t *testing.T) {
+	things := []Spatial{
+		mustRect(Point{1, 1}, []float64{1, 1}),
+		mustRect(Point{-7, -7}, []float64{1, 1}),
+		mustRect(Point{1, 3}, []float64{1, 1}),
+		mustRect(Point{7, 7}, []float64{1, 1}),
+		mustRect(Point{10, 2}, []float64{1, 1}),
+		mustRect(Point{3, 3}, []float64{1, 1}),
 	}
 
 	p := Point{0.5, 0.5}
-	sort.Sort(sortableRects{things, p})
+	sort.Sort(byMinDist{things, p})
 
-	objs := rt.NearestNeighbors(len(things), p)
-	for i := range things {
-		if objs[i] != things[i] {
-			t.Errorf("NearestNeighbors failed at index %d: %v != %v", i, objs[i], things[i])
-		}
-	}
+	for _, tc := range tests(2, 3, 3, things...) {
+		t.Run(tc.name, func(t *testing.T) {
+			rt := tc.tree
 
-	objs = rt.NearestNeighbors(len(things)+2, p)
-	if len(objs) > len(things) {
-		t.Errorf("NearestNeighbors failed: too many elements")
+			objs := rt.NearestNeighbors(3, p)
+			for i := range objs {
+				if objs[i] != things[i] {
+					t.Errorf("NearestNeighbors failed at index %d: %v != %v", i, objs[i], things[i])
+				}
+			}
+
+			objs = rt.NearestNeighbors(len(things)+2, p)
+			if len(objs) > len(things) {
+				t.Errorf("NearestNeighbors failed: too many elements")
+			}
+		})
 	}
 }


### PR DESCRIPTION
Hey,

This pull request adds two things:

1. Filtering for NearestNeighbors searches
2. [Overlap Minimizing Top-down bulk-loading](http://ftp.informatik.rwth-aachen.de/Publications/CEUR-WS/Vol-74/files/FORUM_18.pdf)

I tested the bulk-loading on a small dataset of 50000 objects by querying 200 objects. It lowered both the tree building and the search times to 1/6th.

PR is a bit on the large side, if you have any questions, let me know.