### PR TITLE
PR Add Feature to Retrieve Non-Leaf Bounding Boxes

### DIFF
--- a/rtree.go
+++ b/rtree.go
@@ -252,6 +252,21 @@ func (n *node) split(minGroupSize int) (left, right *node) {
 	return
 }
 
+// getAllBoundingBox traverses tree populating slice of bounding boxes of non-leaf nodes.
+func (n *node) getAllBoundingBox() []*Rect {
+	var rects []*Rect
+	if n.leaf {
+		return rects
+	}
+	for _, e := range n.entries {
+		if e.child == nil {
+			return rects
+		}
+		rects = append(e.child.getAllBoundingBox(), e.bb)
+	}
+	return rects
+}
+
 func assign(e entry, group *node) {
 	if e.child != nil {
 		e.child.parent = group
@@ -484,6 +499,16 @@ func (tree *Rtree) searchIntersect(results []Spatial, n *node, bb *Rect, filters
 func (tree *Rtree) NearestNeighbor(p Point) Spatial {
 	obj, _ := tree.nearestNeighbor(p, tree.root, math.MaxFloat64, nil)
 	return obj
+}
+
+// GetAllBoundingBox returning slice of bounding boxes by traversing tree. Slice
+// includes bounding boxes from all non-leaf nodes.
+func (tree *Rtree) GetAllBoundingBox() []*Rect {
+	var rects []*Rect
+	if tree.root != nil {
+		rects = tree.root.getAllBoundingBox()
+	}
+	return rects
 }
 
 // utilities for sorting slices of entries

--- a/rtree_test.go
+++ b/rtree_test.go
@@ -6,6 +6,7 @@ import (
 	"math/rand"
 	"reflect"
 	"sort"
+	"strconv"
 	"strings"
 	"testing"
 )
@@ -1017,13 +1018,13 @@ func TestGetAllBoundingBox(t *testing.T) {
 	rtbb3 := rt3.GetAllBoundingBox()
 
 	if len(rtbb1) != 3 {
-		t.Errorf("Failed bounding box traversal expected 3 got " + string(len(rtbb1)))
+		t.Errorf("Failed bounding box traversal expected 3 got " + strconv.Itoa(len(rtbb1)))
 	}
 	if len(rtbb2) != 2 {
-		t.Errorf("Failed bounding box traversal expected 3 got " + string(len(rtbb2)))
+		t.Errorf("Failed bounding box traversal expected 2 got " + strconv.Itoa(len(rtbb2)))
 	}
 	if len(rtbb3) != 1 {
-		t.Errorf("Failed bounding box traversal expected 3 got " + string(len(rtbb3)))
+		t.Errorf("Failed bounding box traversal expected 1 got " + strconv.Itoa(len(rtbb3)))
 	}
 }
 

--- a/rtree_test.go
+++ b/rtree_test.go
@@ -972,6 +972,61 @@ func TestNearestNeighbor(t *testing.T) {
 	}
 }
 
+func TestGetAllBoundingBox(t *testing.T) {
+	rt1 := NewTree(2, 3, 3)
+	rt2 := NewTree(2, 2, 4)
+	rt3 := NewTree(2, 4, 8)
+	things := []*Rect{
+		mustRect(Point{0, 0}, []float64{2, 1}),
+		mustRect(Point{3, 1}, []float64{1, 2}),
+		mustRect(Point{1, 2}, []float64{2, 2}),
+		mustRect(Point{8, 6}, []float64{1, 1}),
+		mustRect(Point{10, 3}, []float64{1, 2}),
+		mustRect(Point{11, 7}, []float64{1, 1}),
+		mustRect(Point{10, 10}, []float64{2, 2}),
+		mustRect(Point{2, 3}, []float64{0.5, 1}),
+		mustRect(Point{3, 5}, []float64{1.5, 2}),
+		mustRect(Point{7, 14}, []float64{2.5, 2}),
+		mustRect(Point{15, 6}, []float64{1, 1}),
+		mustRect(Point{4, 3}, []float64{1, 2}),
+		mustRect(Point{1, 7}, []float64{1, 1}),
+		mustRect(Point{10, 5}, []float64{2, 2}),
+	}
+	for _, thing := range things {
+		rt1.Insert(thing)
+	}
+	for _, thing := range things {
+		rt2.Insert(thing)
+	}
+	for _, thing := range things {
+		rt3.Insert(thing)
+	}
+
+	if rt1.Size() != 14 {
+		t.Errorf("Insert failed to insert")
+	}
+	if rt2.Size() != 14 {
+		t.Errorf("Insert failed to insert")
+	}
+	if rt3.Size() != 14 {
+		t.Errorf("Insert failed to insert")
+	}
+
+	rtbb1 := rt1.GetAllBoundingBox()
+	rtbb2 := rt2.GetAllBoundingBox()
+	rtbb3 := rt3.GetAllBoundingBox()
+
+	if len(rtbb1) != 3 {
+		t.Errorf("Failed bounding box traversal expected 3 got " + string(len(rtbb1)))
+	}
+	if len(rtbb2) != 2 {
+		t.Errorf("Failed bounding box traversal expected 3 got " + string(len(rtbb2)))
+	}
+	if len(rtbb3) != 1 {
+		t.Errorf("Failed bounding box traversal expected 3 got " + string(len(rtbb3)))
+	}
+}
+
 type sortableRects struct {
 	r []*Rect
 	p Point


### PR DESCRIPTION
Would you consider accepting this PR which adds functionality to get the bounding boxes of all non-leaf nodes? This is useful for visualizations of the tree and analyzing resulting clusters of data. I have implemented the feature and tests on PR. 

This change introduces one public method ```GetAllBoundingBox``` on ```Rtree``` which calls ```getAllBoundingBox```. ```getAllBoundingBox``` traverses the tree from root building a slice of non-leaf bounding boxes and returns it. 