### PR TITLE
Break filter loop on first refuse

### DIFF
--- a/filter.go
+++ b/filter.go
@@ -1,33 +1,23 @@
 package rtreego
 
 // Filter is an interface for filtering leaves during search. The parameters
-// should be treated as read-only. If refuse is true, the currenty entry will
+// should be treated as read-only. If refuse is true, the current entry will
 // not be added to the result set. If abort is true, the search is aborted and
 // the current result set will be returned.
 type Filter func(results []Spatial, object Spatial) (refuse, abort bool)
 
-// ApplyFilters applies the given filters and returns their consensus.
+// ApplyFilters applies the given filters and returns whether the entry is
+// refused and/or the search should be aborted. If a filter refuses an entry,
+// the following filters are not applied for the entry. If a filter aborts, the
+// search terminates without futher applying any filter.
 func applyFilters(results []Spatial, object Spatial, filters []Filter) (bool, bool) {
-	var refuse, abort bool
 	for _, filter := range filters {
-		ref, abt := filter(results, object)
-
-		if ref {
-			refuse = true
-		}
-
-		if abt {
-			abort = true
-		}
-
-		// some filter after the aborting filter might still refuse the leaf,
-		// so we can only break early if both are true
-		if refuse && abort {
-			break
+		refuse, abort := filter(results, object)
+		if refuse || abort {
+			return refuse, abort
 		}
 	}
-
-	return refuse, abort
+	return false, false
 }
 
 // LimitFilter checks if the results have reached the limit size and aborts if so.


### PR DESCRIPTION
This PR resolves #22. We are running this in production and it greatly improved the performance of our searches by placing more expensive filters at the end of the list of filters.