### PR TITLE
Fixes of OMT bulk-loading

### DIFF
--- a/rtree.go
+++ b/rtree.go
@@ -88,48 +88,24 @@ func (s *dimSorter) Less(i, j int) bool {
 	return s.objs[i].bb.p[s.dim] < s.objs[j].bb.p[s.dim]
 }
 
-// splitByM splits objects into slices of maximum m elements.
-// Split 10 in to 3 will yield 3 + 3 + 3 + 1
-func splitByM(m int, objs []entry) [][]entry {
-	perSlice := len(objs) / m
-
-	numSlices := m
-	if len(objs)%m != 0 {
-		numSlices++
+// split splits objects into slices of maximum k elements.
+func split(k int, objs []entry) [][]entry {
+	n := len(objs) / k
+	if len(objs)%k != 0 {
+		n++
 	}
 
-	split := make([][]entry, numSlices)
-	for i := 0; i < numSlices; i++ {
-		if i == numSlices-1 {
-			split[i] = objs[i*perSlice:]
+	splits := make([][]entry, n)
+	for i := 0; i < n; i++ {
+		if i == n-1 {
+			splits[i] = objs[i*k:]
 			break
 		}
 
-		split[i] = objs[i*perSlice : i*perSlice+perSlice]
+		splits[i] = objs[i*k : (i+1)*k]
 	}
 
-	return split
-}
-
-// splitInS splits objects into s slices and puts the left over elements in the
-// last slice.
-// Split 10 in to 3 will yield 3 + 3 + 4
-func splitInS(s int, objs []entry) [][]entry {
-	split := splitByM(s, objs)
-	if len(split) < 2 {
-		return split
-	}
-
-	last := split[len(split)-1]
-	secondLast := split[len(split)-2]
-
-	if len(last) < len(secondLast) {
-		merged := append(secondLast, last...)
-		split = split[:len(split)-1]
-		split[len(split)-1] = merged
-	}
-
-	return split
+	return splits
 }
 
 func sortByDim(dim int, objs []entry) {
@@ -150,37 +126,51 @@ func (tree *Rtree) bulkLoad(objs []Spatial) {
 		}
 	}
 
-	// root will never be a leaf in the bulk-loaded tree
-	tree.root.leaf = false
-	tree.size = n
 	// following equations are defined in the paper describing OMT
-	tree.height = int(math.Ceil(math.Log(float64(n)) / float64(math.Log(float64(tree.MaxChildren)))))
-	tree.root.level = tree.height
-	nsub := int(math.Pow(float64(tree.MaxChildren), float64(tree.height-1)))
-	s := int(math.Floor(math.Sqrt(math.Ceil(float64(n) / float64(nsub)))))
+	var (
+		N = float64(n)
+		M = float64(tree.MaxChildren)
+	)
+	// Eq1: height of the tree
+	// use log2 instead of log due to rounding errors with log,
+	// eg, math.Log(9) / math.Log(3) > 2
+	h := math.Ceil(math.Log2(N) / math.Log2(M))
 
-	sortByDim(0, entries)
+	// Eq2: size of subtrees at the root
+	nsub := math.Pow(M, h-1)
 
-	// we can preallocate entries here as we know the root will always be
-	// split into s groups
-	tree.root.entries = make([]entry, s)
+	// Inner Eq3: number of subtrees at the root
+	s := math.Ceil(N / nsub)
 
-	// build the root first as we have to split it differently from the subtrees
-	for i, part := range splitInS(s, entries) {
-		child := tree.omt(tree.root.level-1, part, tree.MaxChildren)
-		child.parent = tree.root
+	// Eq3: number of slices
+	S := math.Floor(math.Sqrt(s))
 
-		tree.root.entries[i].bb = child.computeBoundingBox()
-		tree.root.entries[i].child = child
-	}
+	// sort all entries by first dimension
+	sortByDim(int(h)%tree.Dim, entries)
+	tree.root = tree.omt(int(h), int(S), entries, int(s))
+	tree.size = n
+	tree.height = int(h)
 }
 
-// omt the is the recursive part of the Overlap Minimizing Top-loading bulk-
+// omt is the recursive part of the Overlap Minimizing Top-loading bulk-
 // load approach. Returns the root node of a subtree.
-func (tree *Rtree) omt(level int, objs []entry, m int) *node {
+func (tree *Rtree) omt(level, nSlices int, objs []entry, m int) *node {
 	// if number of objects is less than or equal than max children per leaf,
 	// we need to create a leaf node
 	if len(objs) <= m {
+		// as long as the recursion is not at the leaf, call it again
+		if level > 1 {
+			child := tree.omt(level-1, nSlices, objs, m)
+			n := &node{
+				level: level,
+				entries: []entry{{
+					bb:    child.computeBoundingBox(),
+					child: child,
+				}},
+			}
+			child.parent = n
+			return n
+		}
 		return &node{
 			leaf:    true,
 			entries: objs,
@@ -188,25 +178,45 @@ func (tree *Rtree) omt(level int, objs []entry, m int) *node {
 		}
 	}
 
-	// sort the tree on every level by a different dimension than the previous
-	// level, this will prevent overlapping of the branches
-	sortByDim((tree.height-level)%tree.Dim, objs)
+	var (
+		n = &node{
+			level:   level,
+			entries: make([]entry, 0, m),
+		}
 
-	n := &node{
-		level:   level,
-		entries: make([]entry, 0, m),
+		N = float64(len(objs))
+		M = float64(m)
+	)
+
+	// maximum node size given at most M nodes at this level
+	k := math.Ceil(N / M)
+
+	// In the root level, split objs in nSlices. In all other levels,
+	// we use a single slice.
+	var slices [][]entry
+	if nSlices > 1 {
+		minSliceSize := nSlices * int(k)
+		slices = split(minSliceSize, objs)
+	} else {
+		slices = [][]entry{objs}
 	}
 
-	for _, part := range splitByM(m, objs) {
-		child := tree.omt(level-1, part, m)
-		child.parent = n
+	// create sub trees
+	for _, vert := range slices {
+		// sort vertical slice by a different dimension on every level
+		sortByDim((level-1)%tree.Dim, vert)
 
-		n.entries = append(n.entries, entry{
-			bb:    child.computeBoundingBox(),
-			child: child,
-		})
+		// split slice into groups of size k
+		for _, part := range split(int(k), vert) {
+			child := tree.omt(level-1, 1, part, tree.MaxChildren)
+			child.parent = n
+
+			n.entries = append(n.entries, entry{
+				bb:    child.computeBoundingBox(),
+				child: child,
+			})
+		}
 	}
-
 	return n
 }
 


### PR DESCRIPTION
This PR
- fixes the OMT algorithm such that it follows more closely the algorithm described in the original [paper](http://ceur-ws.org/Vol-74/files/FORUM_18.pdf).
- adds a test case that fails without the fixes
- improve the validation tests in `rtree_test.go`

This PR resolves issue #25.