### PR TITLE
KNN preallocate sort buffers

### DIFF
--- a/rtree.go
+++ b/rtree.go
@@ -688,12 +688,7 @@ func (s entrySlice) Less(i, j int) bool {
 func sortEntries(p Point, entries []entry) ([]entry, []float64) {
 	sorted := make([]entry, len(entries))
 	dists := make([]float64, len(entries))
-	for i := 0; i < len(entries); i++ {
-		sorted[i] = entries[i]
-		dists[i] = p.minDist(entries[i].bb)
-	}
-	sort.Sort(entrySlice{sorted, dists})
-	return sorted, dists
+	return sortPreallocEntries(p, entries, sorted, dists)
 }
 
 func sortPreallocEntries(p Point, entries, sorted []entry, dists []float64) ([]entry, []float64) {

--- a/rtree_test.go
+++ b/rtree_test.go
@@ -1108,6 +1108,10 @@ func TestNearestNeighborsAll(t *testing.T) {
 			if len(objs) > len(things) {
 				t.Errorf("NearestNeighbors failed: too many elements")
 			}
+			if len(objs) < len(things) {
+				t.Errorf("NearestNeighbors failed: not enough elements")
+			}
+
 		})
 	}
 }


### PR DESCRIPTION
This PR preallocates the buffers used to sort entries in the KNN search. With this fix the pressure on the garbage collector is greatly reduced in long running workloads.

This PR resolves issue #24.

This PR depends on the fixes of PR #26! 