### PR TITLE
geom: change intersect() to return if the rectangles intersect

### DIFF
--- a/geom.go
+++ b/geom.go
@@ -248,7 +248,7 @@ func (r *Rect) containsRect(r2 *Rect) bool {
 
 // intersect computes the intersection of two rectangles.  If no intersection
 // exists, the intersection is nil.
-func intersect(r1, r2 *Rect) *Rect {
+func intersect(r1, r2 *Rect) bool {
 	dim := len(r1.p)
 	if len(r2.p) != dim {
 		panic(DimError{dim, len(r2.p)})
@@ -283,17 +283,13 @@ func intersect(r1, r2 *Rect) *Rect {
 	// Enforced by constructor: a1 <= b1 and a2 <= b2.  So we can just
 	// check the endpoints.
 
-	p := make([]float64, dim)
-	q := make([]float64, dim)
-	for i := range p {
+	for i := range r1.p {
 		a1, b1, a2, b2 := r1.p[i], r1.q[i], r2.p[i], r2.q[i]
 		if b2 <= a1 || b1 <= a2 {
-			return nil
+			return false
 		}
-		p[i] = math.Max(a1, a2)
-		q[i] = math.Min(b1, b2)
 	}
-	return &Rect{p, q}
+	return true
 }
 
 // ToRect constructs a rectangle containing p with side lengths 2*tol.

--- a/geom_test.go
+++ b/geom_test.go
@@ -196,8 +196,8 @@ func TestNoIntersection(t *testing.T) {
 
 	// rect1 and rect2 fail to overlap in just one dimension (second)
 
-	if intersect := intersect(rect1, rect2); intersect != nil {
-		t.Errorf("Expected intersect(%v, %v) == nil, got %v", rect1, rect2, intersect)
+	if intersect(rect1, rect2) {
+		t.Errorf("Expected intersect(%v, %v) == false", rect1, rect2)
 	}
 }
 
@@ -212,8 +212,8 @@ func TestNoIntersectionJustTouches(t *testing.T) {
 
 	// rect1 and rect2 fail to overlap in just one dimension (second)
 
-	if intersect := intersect(rect1, rect2); intersect != nil {
-		t.Errorf("Expected intersect(%v, %v) == nil, got %v", rect1, rect2, intersect)
+	if intersect(rect1, rect2) {
+		t.Errorf("Expected intersect(%v, %v) == false", rect1, rect2)
 	}
 }
 
@@ -229,11 +229,8 @@ func TestContainmentIntersection(t *testing.T) {
 	r := Point{1, 2.2, 3.3}
 	s := Point{1.5, 2.7, 3.8}
 
-	actual := intersect(rect1, rect2)
-	d1 := r.dist(actual.p)
-	d2 := s.dist(actual.q)
-	if d1 > EPS || d2 > EPS {
-		t.Errorf("intersect(%v, %v) != %v, %v, got %v", rect1, rect2, r, s, actual)
+	if !intersect(rect1, rect2) {
+		t.Errorf("intersect(%v, %v) != %v, %v", rect1, rect2, r, s)
 	}
 }
 
@@ -249,11 +246,8 @@ func TestOverlapIntersection(t *testing.T) {
 	r := Point{1, 4, 3}
 	s := Point{2, 4.5, 3.5}
 
-	actual := intersect(rect1, rect2)
-	d1 := r.dist(actual.p)
-	d2 := s.dist(actual.q)
-	if d1 > EPS || d2 > EPS {
-		t.Errorf("intersect(%v, %v) != %v, %v, got %v", rect1, rect2, r, s, actual)
+	if !intersect(rect1, rect2) {
+		t.Errorf("intersect(%v, %v) != %v, %v", rect1, rect2, r, s)
 	}
 }
 

--- a/rtree.go
+++ b/rtree.go
@@ -623,7 +623,7 @@ func (tree *Rtree) SearchIntersectWithLimit(k int, bb *Rect) []Spatial {
 
 func (tree *Rtree) searchIntersect(results []Spatial, n *node, bb *Rect, filters []Filter) []Spatial {
 	for _, e := range n.entries {
-		if intersect(e.bb, bb) == nil {
+		if !intersect(e.bb, bb) {
 			continue
 		}
 


### PR DESCRIPTION
Previously, intersect() returned an unused *Rect and searchIntersect()
only checked if it was null.  Allocating this *Rect is costly and
pointless.

This commit changes intersect() to return if the two Rects intersect
each other.  In internal benchmarks this improves performance by 50% and
reduces allocations by over 95%.