### PR TITLE
fix tree corruption upon delete then insert

### DIFF
--- a/rtree.go
+++ b/rtree.go
@@ -163,9 +163,11 @@ func (tree *Rtree) omt(level, nSlices int, objs []entry, m int) *node {
 			child.parent = n
 			return n
 		}
+		entries := make([]entry, len(objs))
+		copy(entries, objs)
 		return &node{
 			leaf:    true,
-			entries: objs,
+			entries: entries,
 			level:   level,
 		}
 	}

--- a/rtree_test.go
+++ b/rtree_test.go
@@ -860,6 +860,28 @@ func TestDeleteWithComparator(t *testing.T) {
 	}
 }
 
+func TestDeleteThenInsert(t *testing.T) {
+	tol := 1e-3
+	things := []Spatial{
+		mustRect(Point{3, 1}, []float64{tol, tol}),
+		mustRect(Point{1, 2}, []float64{tol, tol}),
+		mustRect(Point{2, 6}, []float64{tol, tol}),
+		mustRect(Point{3, 6}, []float64{tol, tol}),
+		mustRect(Point{2, 8}, []float64{tol, tol}),
+	}
+	rt := NewTree(2, 2, 2, things...)
+
+	if ok := rt.Delete(things[3]); !ok {
+		t.Fatalf("%#v", things[3])
+	}
+	rt.Insert(things[3])
+
+	// Deleting and then inserting things[3] should not affect things[4].
+	if ok := rt.Delete(things[4]); !ok {
+		t.Fatalf("%#v", things[4])
+	}
+}
+
 func TestSearchIntersect(t *testing.T) {
 	things := []Spatial{
 		mustRect(Point{0, 0}, []float64{2, 1}),


### PR DESCRIPTION
This data corruption is due to the fact that entries of different nodes share the same slice.
For example, assume

nodeA.entries == buf[:3]
nodeB.entries == buf[3:]

when we do

nodeA.entries = append(nodeA.entries, foo)

we accidentally make nodeB.entries[0] == foo
and nodeB's data is corrupted.

This issue is likely the cause behind
https://github.com/dhconnelly/rtreego/issues/28