### PR TITLE
improve search performance by reduce overlapping

### DIFF
--- a/rtree.go
+++ b/rtree.go
@@ -592,7 +592,8 @@ func (tree *Rtree) condenseTree(n *node) {
 		n = n.parent
 	}
 
-	for _, n := range deleted {
+	for i := len(deleted) - 1; i >= 0; i-- {
+		n := deleted[i]
 		// reinsert entry so that it will remain at the same level as before
 		e := entry{n.computeBoundingBox(), n, nil}
 		tree.insert(e, n.level+1)


### PR DESCRIPTION
Similar to the logic applied by bulk-loading, we should create
rectangles from top to bottom.