### PR TITLE
Reduce unnecessary allocations and sorting to improve performance

### DIFF
--- a/rtree.go
+++ b/rtree.go
@@ -739,9 +739,20 @@ func (tree *Rtree) nearestNeighbor(p Point, n *node, d float64, nearest Spatial)
 			}
 		}
 	} else {
-		branches, dists := sortEntries(p, n.entries)
-		branches = pruneEntries(p, branches, dists)
-		for _, e := range branches {
+		minMinMaxDist := math.MaxFloat64
+		for _, e := range n.entries {
+			minMaxDist := p.minMaxDist(e.bb)
+			if minMaxDist < minMinMaxDist {
+				minMinMaxDist = minMaxDist
+			}
+		}
+
+		for _, e := range n.entries {
+			minDist := p.minDist(e.bb)
+			if minDist > minMinMaxDist {
+				continue
+			}
+
 			subNearest, dist := tree.nearestNeighbor(p, e.child, d, nearest)
 			if dist < d {
 				d = dist

--- a/rtree.go
+++ b/rtree.go
@@ -739,6 +739,14 @@ func (tree *Rtree) nearestNeighbor(p Point, n *node, d float64, nearest Spatial)
 			}
 		}
 	} else {
+		// Search only through entries with minDist <= minMinMaxDist,
+		// where minDist is the distance between a point and a rectangle,
+		// and minMaxDist is the smallest value among the maximum distance across all axes.
+		//
+		// Entries with minDist > minMinMaxDist are guaranteed to be farther away than some other entry.
+		//
+		// For more details, please consult
+		// N. Roussopoulos, S. Kelley and F. Vincent, ACM SIGMOD, pages 71-79, 1995.
 		minMinMaxDist := math.MaxFloat64
 		for _, e := range n.entries {
 			minMaxDist := p.minMaxDist(e.bb)


### PR DESCRIPTION
As shown in the pprof graph to be attached in the pull request,
the previous implementation has the following time spent:

gcBgMarkWorker 24.37%
mallocgc       15.21%
sort.Sort      9.06%
gcWriteBarrier 7.2%

which adds up to almost half the running time.

![before](https://user-images.githubusercontent.com/765222/184499831-d19e6dbb-6659-41e6-ba07-6cd6d60c0bdb.svg)

The pprof graph after this change (to be also attached) shows that these memory allocations
and sorting operations are indeed reduced.

![after](https://user-images.githubusercontent.com/765222/184499867-a961d2a4-9d2f-49e5-b536-82909c8b86e2.svg)

