### PR TITLE
make entry.bb plain Rect struct instead of pointer

### DIFF
--- a/geom.go
+++ b/geom.go
@@ -49,7 +49,7 @@ func (p Point) dist(q Point) float64 {
 //
 // Implemented per Definition 2 of "Nearest Neighbor Queries" by
 // N. Roussopoulos, S. Kelley and F. Vincent, ACM SIGMOD, pages 71-79, 1995.
-func (p Point) minDist(r *Rect) float64 {
+func (p Point) minDist(r Rect) float64 {
 	if len(p) != len(r.p) {
 		panic(DimError{len(p), len(r.p)})
 	}
@@ -75,7 +75,7 @@ func (p Point) minDist(r *Rect) float64 {
 //
 // Implemented per Definition 4 of "Nearest Neighbor Queries" by
 // N. Roussopoulos, S. Kelley and F. Vincent, ACM SIGMOD, pages 71-79, 1995.
-func (p Point) minMaxDist(r *Rect) float64 {
+func (p Point) minMaxDist(r Rect) float64 {
 	if len(p) != len(r.p) {
 		panic(DimError{len(p), len(r.p)})
 	}
@@ -128,17 +128,17 @@ type Rect struct {
 }
 
 // PointCoord returns the coordinate of the point of the rectangle at i
-func (r *Rect) PointCoord(i int) float64 {
+func (r Rect) PointCoord(i int) float64 {
 	return r.p[i]
 }
 
 // LengthsCoord returns the coordinate of the lengths of the rectangle at i
-func (r *Rect) LengthsCoord(i int) float64 {
+func (r Rect) LengthsCoord(i int) float64 {
 	return r.q[i] - r.p[i]
 }
 
 // Equal returns true if the two rectangles are equal
-func (r *Rect) Equal(other *Rect) bool {
+func (r Rect) Equal(other Rect) bool {
 	for i, e := range r.p {
 		if e != other.p[i] {
 			return false
@@ -152,7 +152,7 @@ func (r *Rect) Equal(other *Rect) bool {
 	return true
 }
 
-func (r *Rect) String() string {
+func (r Rect) String() string {
 	s := make([]string, len(r.p))
 	for i, a := range r.p {
 		b := r.q[i]
@@ -164,8 +164,8 @@ func (r *Rect) String() string {
 // NewRect constructs and returns a pointer to a Rect given a corner point and
 // the lengths of each dimension.  The point p should be the most-negative point
 // on the rectangle (in every dimension) and every length should be positive.
-func NewRect(p Point, lengths []float64) (r *Rect, err error) {
-	r = new(Rect)
+func NewRect(p Point, lengths []float64) (r Rect, err error) {
+	// r = new(Rect)
 	r.p = p
 	if len(p) != len(lengths) {
 		err = &DimError{len(p), len(lengths)}
@@ -183,7 +183,7 @@ func NewRect(p Point, lengths []float64) (r *Rect, err error) {
 }
 
 // NewRectFromPoints constructs and returns a pointer to a Rect given a corner points.
-func NewRectFromPoints(minPoint, maxPoint Point) (r *Rect, err error) {
+func NewRectFromPoints(minPoint, maxPoint Point) (r Rect, err error) {
 	if len(minPoint) != len(maxPoint) {
 		err = &DimError{len(minPoint), len(maxPoint)}
 		return
@@ -197,12 +197,12 @@ func NewRectFromPoints(minPoint, maxPoint Point) (r *Rect, err error) {
 		}
 	}
 
-	r = &Rect{p: minPoint, q: maxPoint}
+	r = Rect{p: minPoint, q: maxPoint}
 	return
 }
 
 // Size computes the measure of a rectangle (the product of its side lengths).
-func (r *Rect) Size() float64 {
+func (r Rect) Size() float64 {
 	size := 1.0
 	for i, a := range r.p {
 		b := r.q[i]
@@ -212,7 +212,7 @@ func (r *Rect) Size() float64 {
 }
 
 // margin computes the sum of the edge lengths of a rectangle.
-func (r *Rect) margin() float64 {
+func (r Rect) margin() float64 {
 	// The number of edges in an n-dimensional rectangle is n * 2^(n-1)
 	// (http://en.wikipedia.org/wiki/Hypercube_graph).  Thus the number
 	// of edges of length (ai - bi), where the rectangle is determined
@@ -230,7 +230,7 @@ func (r *Rect) margin() float64 {
 }
 
 // containsPoint tests whether p is located inside or on the boundary of r.
-func (r *Rect) containsPoint(p Point) bool {
+func (r Rect) containsPoint(p Point) bool {
 	if len(p) != len(r.p) {
 		panic(DimError{len(r.p), len(p)})
 	}
@@ -247,7 +247,7 @@ func (r *Rect) containsPoint(p Point) bool {
 }
 
 // containsRect tests whether r2 is is located inside r1.
-func (r *Rect) containsRect(r2 *Rect) bool {
+func (r Rect) containsRect(r2 Rect) bool {
 	if len(r.p) != len(r2.p) {
 		panic(DimError{len(r.p), len(r2.p)})
 	}
@@ -267,7 +267,7 @@ func (r *Rect) containsRect(r2 *Rect) bool {
 
 // intersect computes the intersection of two rectangles.  If no intersection
 // exists, the intersection is nil.
-func intersect(r1, r2 *Rect) bool {
+func intersect(r1, r2 Rect) bool {
 	dim := len(r1.p)
 	if len(r2.p) != dim {
 		panic(DimError{dim, len(r2.p)})
@@ -312,19 +312,19 @@ func intersect(r1, r2 *Rect) bool {
 }
 
 // ToRect constructs a rectangle containing p with side lengths 2*tol.
-func (p Point) ToRect(tol float64) *Rect {
+func (p Point) ToRect(tol float64) Rect {
 	dim := len(p)
 	a, b := make([]float64, dim), make([]float64, dim)
 	for i := range p {
 		a[i] = p[i] - tol
 		b[i] = p[i] + tol
 	}
-	return &Rect{a, b}
+	return Rect{a, b}
 }
 
 // boundingBox constructs the smallest rectangle containing both r1 and r2.
-func boundingBox(r1, r2 *Rect) (bb *Rect) {
-	bb = new(Rect)
+func boundingBox(r1, r2 Rect) (bb Rect) {
+	// bb = new(Rect)
 	dim := len(r1.p)
 	bb.p = make([]float64, dim)
 	bb.q = make([]float64, dim)
@@ -347,7 +347,7 @@ func boundingBox(r1, r2 *Rect) (bb *Rect) {
 }
 
 // boundingBoxN constructs the smallest rectangle containing all of r...
-func boundingBoxN(rects ...*Rect) (bb *Rect) {
+func boundingBoxN(rects ...Rect) (bb Rect) {
 	if len(rects) == 1 {
 		bb = rects[0]
 		return

--- a/geom.go
+++ b/geom.go
@@ -165,7 +165,6 @@ func (r Rect) String() string {
 // the lengths of each dimension.  The point p should be the most-negative point
 // on the rectangle (in every dimension) and every length should be positive.
 func NewRect(p Point, lengths []float64) (r Rect, err error) {
-	// r = new(Rect)
 	r.p = p
 	if len(p) != len(lengths) {
 		err = &DimError{len(p), len(lengths)}
@@ -324,7 +323,6 @@ func (p Point) ToRect(tol float64) Rect {
 
 // boundingBox constructs the smallest rectangle containing both r1 and r2.
 func boundingBox(r1, r2 Rect) (bb Rect) {
-	// bb = new(Rect)
 	dim := len(r1.p)
 	bb.p = make([]float64, dim)
 	bb.q = make([]float64, dim)

--- a/geom_test.go
+++ b/geom_test.go
@@ -360,7 +360,7 @@ func TestMinDistZero(t *testing.T) {
 
 func TestMinDistPositive(t *testing.T) {
 	p := Point{1, 2, 3}
-	r := &Rect{Point{-1, -4, 7}, Point{2, -2, 9}}
+	r := Rect{Point{-1, -4, 7}, Point{2, -2, 9}}
 	expected := float64((-2-2)*(-2-2) + (7-3)*(7-3))
 	if d := p.minDist(r); math.Abs(d-expected) > EPS {
 		t.Errorf("Expected %v.minDist(%v) == %v, got %v", p, r, expected, d)
@@ -369,7 +369,7 @@ func TestMinDistPositive(t *testing.T) {
 
 func TestMinMaxdist(t *testing.T) {
 	p := Point{-3, -2, -1}
-	r := &Rect{Point{0, 0, 0}, Point{1, 2, 3}}
+	r := Rect{Point{0, 0, 0}, Point{1, 2, 3}}
 
 	// furthest points from p on the faces closest to p in each dimension
 	q1 := Point{0, 2, 3}

--- a/rtree.go
+++ b/rtree.go
@@ -220,7 +220,7 @@ func (n *node) String() string {
 
 // entry represents a spatial index record stored in a tree node.
 type entry struct {
-	bb    *Rect // bounding-box of all children of this entry
+	bb    Rect // bounding-box of all children of this entry
 	child *node
 	obj   Spatial
 }
@@ -234,7 +234,7 @@ func (e entry) String() string {
 
 // Spatial is an interface for objects that can be stored in an Rtree and queried.
 type Spatial interface {
-	Bounds() *Rect
+	Bounds() Rect
 }
 
 // Insertion
@@ -346,8 +346,8 @@ func (n *node) getEntry() *entry {
 }
 
 // computeBoundingBox finds the MBR of the children of n.
-func (n *node) computeBoundingBox() (bb *Rect) {
-	childBoxes := make([]*Rect, len(n.entries))
+func (n *node) computeBoundingBox() (bb Rect) {
+	childBoxes := make([]Rect, len(n.entries))
 	for i, e := range n.entries {
 		childBoxes[i] = e.bb
 	}
@@ -404,8 +404,8 @@ func (n *node) split(minGroupSize int) (left, right *node) {
 }
 
 // getAllBoundingBoxes traverses tree populating slice of bounding boxes of non-leaf nodes.
-func (n *node) getAllBoundingBoxes() []*Rect {
-	var rects []*Rect
+func (n *node) getAllBoundingBoxes() []Rect {
+	var rects []Rect
 	if n.leaf {
 		return rects
 	}
@@ -605,7 +605,7 @@ func (tree *Rtree) condenseTree(n *node) {
 // SearchIntersect returns all objects that intersect the specified rectangle.
 // Implemented per Section 3.1 of "R-trees: A Dynamic Index Structure for
 // Spatial Searching" by A. Guttman, Proceedings of ACM SIGMOD, p. 47-57, 1984.
-func (tree *Rtree) SearchIntersect(bb *Rect, filters ...Filter) []Spatial {
+func (tree *Rtree) SearchIntersect(bb Rect, filters ...Filter) []Spatial {
 	return tree.searchIntersect([]Spatial{}, tree.root, bb, filters)
 }
 
@@ -615,7 +615,7 @@ func (tree *Rtree) SearchIntersect(bb *Rect, filters ...Filter) []Spatial {
 //
 // Kept for backwards compatibility, please use SearchIntersect with a
 // LimitFilter.
-func (tree *Rtree) SearchIntersectWithLimit(k int, bb *Rect) []Spatial {
+func (tree *Rtree) SearchIntersectWithLimit(k int, bb Rect) []Spatial {
 	// backwards compatibility, previous implementation didn't limit results if
 	// k was negative.
 	if k < 0 {
@@ -624,7 +624,7 @@ func (tree *Rtree) SearchIntersectWithLimit(k int, bb *Rect) []Spatial {
 	return tree.SearchIntersect(bb, LimitFilter(k))
 }
 
-func (tree *Rtree) searchIntersect(results []Spatial, n *node, bb *Rect, filters []Filter) []Spatial {
+func (tree *Rtree) searchIntersect(results []Spatial, n *node, bb Rect, filters []Filter) []Spatial {
 	for _, e := range n.entries {
 		if !intersect(e.bb, bb) {
 			continue
@@ -656,8 +656,8 @@ func (tree *Rtree) NearestNeighbor(p Point) Spatial {
 
 // GetAllBoundingBoxes returning slice of bounding boxes by traversing tree. Slice
 // includes bounding boxes from all non-leaf nodes.
-func (tree *Rtree) GetAllBoundingBoxes() []*Rect {
-	var rects []*Rect
+func (tree *Rtree) GetAllBoundingBoxes() []Rect {
+	var rects []Rect
 	if tree.root != nil {
 		rects = tree.root.getAllBoundingBoxes()
 	}

--- a/rtree_test.go
+++ b/rtree_test.go
@@ -36,11 +36,46 @@ func tests(dim, min, max int, objs ...Spatial) []*testCase {
 	}
 }
 
-func (r *Rect) Bounds() *Rect {
+func (r Rect) Bounds() Rect {
 	return r
 }
 
-func mustRect(p Point, widths []float64) *Rect {
+func rectEq(a, b Rect) bool {
+	if len(a.p) != len(b.p) {
+		return false
+	}
+	for i := 0; i < len(a.p); i++ {
+		if a.p[i] != b.p[i] {
+			return false
+		}
+	}
+
+	if len(a.q) != len(b.q) {
+		return false
+	}
+	for i := 0; i < len(a.q); i++ {
+		if a.q[i] != b.q[i] {
+			return false
+		}
+	}
+
+	return true
+}
+
+func entryEq(a, b entry) bool {
+	if !rectEq(a.bb, b.bb) {
+		return false
+	}
+	if a.child != b.child {
+		return false
+	}
+	if a.obj != b.obj {
+		return false
+	}
+	return true
+}
+
+func mustRect(p Point, widths []float64) Rect {
 	r, err := NewRect(p, widths)
 	if err != nil {
 		panic(err)
@@ -137,8 +172,8 @@ func indexOf(objs []Spatial, obj Spatial) int {
 }
 
 var chooseLeafNodeTests = []struct {
-	bb0, bb1, bb2 *Rect // leaf bounding boxes
-	exp           int   // expected chosen leaf
+	bb0, bb1, bb2 Rect // leaf bounding boxes
+	exp           int  // expected chosen leaf
 	desc          string
 	level         int
 }{
@@ -209,7 +244,7 @@ func TestPickSeeds(t *testing.T) {
 	entry3 := entry{bb: mustRect(Point{-1, -1}, []float64{1, 2})}
 	n := node{entries: []entry{entry1, entry2, entry3}}
 	left, right := n.pickSeeds()
-	if n.entries[left] != entry1 || n.entries[right] != entry3 {
+	if !entryEq(n.entries[left], entry1) || !entryEq(n.entries[right], entry3) {
 		t.Errorf("expected entries %d, %d", 1, 3)
 	}
 }
@@ -227,7 +262,7 @@ func TestPickNext(t *testing.T) {
 	entries := []entry{entry1, entry2, entry3}
 
 	chosen := pickNext(left, right, entries)
-	if entries[chosen] != entry2 {
+	if !entryEq(entries[chosen], entry2) {
 		t.Errorf("expected entry %d", 3)
 	}
 }
@@ -420,14 +455,14 @@ func TestInsertNoSplit(t *testing.T) {
 		t.Errorf("Insert failed to increase tree size")
 	}
 
-	if len(rt.root.entries) != 1 || rt.root.entries[0].obj.(*Rect) != thing {
+	if len(rt.root.entries) != 1 || !rectEq(rt.root.entries[0].obj.(Rect), thing) {
 		t.Errorf("Insert failed to insert thing into root entries")
 	}
 }
 
 func TestInsertSplitRoot(t *testing.T) {
 	rt := NewTree(2, 3, 3)
-	things := []*Rect{
+	things := []Rect{
 		mustRect(Point{0, 0}, []float64{2, 1}),
 		mustRect(Point{3, 1}, []float64{1, 2}),
 		mustRect(Point{1, 2}, []float64{2, 2}),
@@ -455,7 +490,7 @@ func TestInsertSplitRoot(t *testing.T) {
 
 func TestInsertSplit(t *testing.T) {
 	rt := NewTree(2, 3, 3)
-	things := []*Rect{
+	things := []Rect{
 		mustRect(Point{0, 0}, []float64{2, 1}),
 		mustRect(Point{3, 1}, []float64{1, 2}),
 		mustRect(Point{1, 2}, []float64{2, 2}),
@@ -486,7 +521,7 @@ func TestInsertSplit(t *testing.T) {
 
 func TestInsertSplitSecondLevel(t *testing.T) {
 	rt := NewTree(2, 3, 3)
-	things := []*Rect{
+	things := []Rect{
 		mustRect(Point{0, 0}, []float64{2, 1}),
 		mustRect(Point{3, 1}, []float64{1, 2}),
 		mustRect(Point{1, 2}, []float64{2, 2}),
@@ -565,7 +600,7 @@ func TestBulkLoadingValidity(t *testing.T) {
 
 func TestFindLeaf(t *testing.T) {
 	rt := NewTree(2, 3, 3)
-	things := []*Rect{
+	rects := []Rect{
 		mustRect(Point{0, 0}, []float64{2, 1}),
 		mustRect(Point{3, 1}, []float64{1, 2}),
 		mustRect(Point{1, 2}, []float64{2, 2}),
@@ -577,6 +612,11 @@ func TestFindLeaf(t *testing.T) {
 		mustRect(Point{0, 8}, []float64{1, 2}),
 		mustRect(Point{1, 8}, []float64{1, 2}),
 	}
+	things := []Spatial{}
+	for i := range rects {
+		things = append(things, &rects[i])
+	}
+
 	for _, thing := range things {
 		rt.Insert(thing)
 	}
@@ -585,7 +625,7 @@ func TestFindLeaf(t *testing.T) {
 		leaf := rt.findLeaf(rt.root, thing, defaultComparator)
 		if leaf == nil {
 			printNode(rt.root, 0)
-			t.Errorf("Unable to find leaf containing an entry after insertion!")
+			t.Fatalf("Unable to find leaf containing an entry after insertion!")
 		}
 		var found *Rect
 		for _, other := range leaf.entries {
@@ -604,7 +644,7 @@ func TestFindLeaf(t *testing.T) {
 
 func TestFindLeafDoesNotExist(t *testing.T) {
 	rt := NewTree(2, 3, 3)
-	things := []*Rect{
+	things := []Rect{
 		mustRect(Point{0, 0}, []float64{2, 1}),
 		mustRect(Point{3, 1}, []float64{1, 2}),
 		mustRect(Point{1, 2}, []float64{2, 2}),
@@ -629,7 +669,7 @@ func TestFindLeafDoesNotExist(t *testing.T) {
 
 func TestCondenseTreeEliminate(t *testing.T) {
 	rt := NewTree(2, 3, 3)
-	things := []*Rect{
+	things := []Rect{
 		mustRect(Point{0, 0}, []float64{2, 1}),
 		mustRect(Point{3, 1}, []float64{1, 2}),
 		mustRect(Point{1, 2}, []float64{2, 2}),
@@ -664,7 +704,7 @@ func TestCondenseTreeEliminate(t *testing.T) {
 
 func TestChooseNodeNonLeaf(t *testing.T) {
 	rt := NewTree(2, 3, 3)
-	things := []*Rect{
+	things := []Rect{
 		mustRect(Point{0, 0}, []float64{2, 1}),
 		mustRect(Point{3, 1}, []float64{1, 2}),
 		mustRect(Point{1, 2}, []float64{2, 2}),
@@ -690,7 +730,7 @@ func TestChooseNodeNonLeaf(t *testing.T) {
 
 func TestInsertNonLeaf(t *testing.T) {
 	rt := NewTree(2, 3, 3)
-	things := []*Rect{
+	things := []Rect{
 		mustRect(Point{0, 0}, []float64{2, 1}),
 		mustRect(Point{3, 1}, []float64{1, 2}),
 		mustRect(Point{1, 2}, []float64{2, 2}),
@@ -711,15 +751,19 @@ func TestInsertNonLeaf(t *testing.T) {
 	rt.insert(e, 2)
 
 	expected := rt.root.entries[1].child
-	if expected.entries[1].obj != obj {
+	if !rectEq(expected.entries[1].obj.(Rect), obj) {
 		t.Errorf("insert failed to insert entry at correct level")
 	}
 }
 
 func TestDeleteFlatten(t *testing.T) {
-	things := []Spatial{
+	rects := []Rect{
 		mustRect(Point{0, 0}, []float64{2, 1}),
 		mustRect(Point{3, 1}, []float64{1, 2}),
+	}
+	things := []Spatial{}
+	for i := range rects {
+		things = append(things, &rects[i])
 	}
 
 	for _, tc := range tests(2, 3, 3, things...) {
@@ -733,7 +777,7 @@ func TestDeleteFlatten(t *testing.T) {
 }
 
 func TestDelete(t *testing.T) {
-	things := []Spatial{
+	rects := []Rect{
 		mustRect(Point{0, 0}, []float64{2, 1}),
 		mustRect(Point{3, 1}, []float64{1, 2}),
 		mustRect(Point{1, 2}, []float64{2, 2}),
@@ -744,6 +788,10 @@ func TestDelete(t *testing.T) {
 		mustRect(Point{1, 6}, []float64{1, 2}),
 		mustRect(Point{0, 8}, []float64{1, 2}),
 		mustRect(Point{1, 8}, []float64{1, 2}),
+	}
+	things := []Spatial{}
+	for i := range rects {
+		things = append(things, &rects[i])
 	}
 
 	for _, tc := range tests(2, 3, 3, things...) {
@@ -778,12 +826,17 @@ func TestDelete(t *testing.T) {
 
 func TestDeleteWithDepthChange(t *testing.T) {
 	rt := NewTree(2, 3, 3)
-	things := []*Rect{
+	rects := []Rect{
 		mustRect(Point{0, 0}, []float64{2, 1}),
 		mustRect(Point{3, 1}, []float64{1, 2}),
 		mustRect(Point{1, 2}, []float64{2, 2}),
 		mustRect(Point{8, 6}, []float64{1, 1}),
 	}
+	things := []Spatial{}
+	for i := range rects {
+		things = append(things, &rects[i])
+	}
+
 	for _, thing := range things {
 		rt.Insert(thing)
 	}
@@ -801,7 +854,7 @@ func TestDeleteWithDepthChange(t *testing.T) {
 func TestDeleteWithComparator(t *testing.T) {
 	type IDRect struct {
 		ID string
-		*Rect
+		Rect
 	}
 
 	things := []Spatial{
@@ -833,7 +886,7 @@ func TestDeleteWithComparator(t *testing.T) {
 			for len(things) > 0 {
 				i := rand.Int() % len(things)
 				// make a deep copy
-				copy := &IDRect{things[i].(*IDRect).ID, &(*things[i].(*IDRect).Rect)}
+				copy := &IDRect{things[i].(*IDRect).ID, things[i].(*IDRect).Rect}
 				things2 = append(things2, copy)
 
 				if !cmp(things[i], copy) {
@@ -862,13 +915,18 @@ func TestDeleteWithComparator(t *testing.T) {
 
 func TestDeleteThenInsert(t *testing.T) {
 	tol := 1e-3
-	things := []Spatial{
+	rects := []Rect{
 		mustRect(Point{3, 1}, []float64{tol, tol}),
 		mustRect(Point{1, 2}, []float64{tol, tol}),
 		mustRect(Point{2, 6}, []float64{tol, tol}),
 		mustRect(Point{3, 6}, []float64{tol, tol}),
 		mustRect(Point{2, 8}, []float64{tol, tol}),
 	}
+	things := []Spatial{}
+	for i := range rects {
+		things = append(things, &rects[i])
+	}
+
 	rt := NewTree(2, 2, 2, things...)
 
 	if ok := rt.Delete(things[3]); !ok {
@@ -883,7 +941,7 @@ func TestDeleteThenInsert(t *testing.T) {
 }
 
 func TestSearchIntersect(t *testing.T) {
-	things := []Spatial{
+	rects := []Rect{
 		mustRect(Point{0, 0}, []float64{2, 1}),
 		mustRect(Point{3, 1}, []float64{1, 2}),
 		mustRect(Point{1, 2}, []float64{2, 2}),
@@ -894,6 +952,10 @@ func TestSearchIntersect(t *testing.T) {
 		mustRect(Point{3, 6}, []float64{1, 2}),
 		mustRect(Point{2, 8}, []float64{1, 2}),
 		mustRect(Point{3, 8}, []float64{1, 2}),
+	}
+	things := []Spatial{}
+	for i := range rects {
+		things = append(things, &rects[i])
 	}
 
 	for _, tc := range tests(2, 3, 3, things...) {
@@ -916,7 +978,7 @@ func TestSearchIntersect(t *testing.T) {
 }
 
 func TestSearchIntersectWithLimit(t *testing.T) {
-	things := []Spatial{
+	rects := []Rect{
 		mustRect(Point{0, 0}, []float64{2, 1}),
 		mustRect(Point{3, 1}, []float64{1, 2}),
 		mustRect(Point{1, 2}, []float64{2, 2}),
@@ -927,6 +989,10 @@ func TestSearchIntersectWithLimit(t *testing.T) {
 		mustRect(Point{3, 6}, []float64{1, 2}),
 		mustRect(Point{2, 8}, []float64{1, 2}),
 		mustRect(Point{3, 8}, []float64{1, 2}),
+	}
+	things := []Spatial{}
+	for i := range rects {
+		things = append(things, &rects[i])
 	}
 
 	for _, tc := range tests(2, 3, 3, things...) {
@@ -972,7 +1038,7 @@ func TestSearchIntersectWithLimit(t *testing.T) {
 }
 
 func TestSearchIntersectWithTestFilter(t *testing.T) {
-	things := []Spatial{
+	rects := []Rect{
 		mustRect(Point{0, 0}, []float64{2, 1}),
 		mustRect(Point{3, 1}, []float64{1, 2}),
 		mustRect(Point{1, 2}, []float64{2, 2}),
@@ -983,6 +1049,10 @@ func TestSearchIntersectWithTestFilter(t *testing.T) {
 		mustRect(Point{3, 6}, []float64{1, 2}),
 		mustRect(Point{2, 8}, []float64{1, 2}),
 		mustRect(Point{3, 8}, []float64{1, 2}),
+	}
+	things := []Spatial{}
+	for i := range rects {
+		things = append(things, &rects[i])
 	}
 
 	for _, tc := range tests(2, 3, 3, things...) {
@@ -1041,17 +1111,17 @@ func TestSearchIntersectNoResults(t *testing.T) {
 }
 
 func TestSortEntries(t *testing.T) {
-	objs := []*Rect{
+	objs := []Rect{
 		mustRect(Point{1, 1}, []float64{1, 1}),
 		mustRect(Point{2, 2}, []float64{1, 1}),
 		mustRect(Point{3, 3}, []float64{1, 1})}
 	entries := []entry{
-		{objs[2], nil, objs[2]},
-		{objs[1], nil, objs[1]},
-		{objs[0], nil, objs[0]},
+		{objs[2], nil, &objs[2]},
+		{objs[1], nil, &objs[1]},
+		{objs[0], nil, &objs[0]},
 	}
 	sorted, dists := sortEntries(Point{0, 0}, entries)
-	if sorted[0] != entries[2] || sorted[1] != entries[1] || sorted[2] != entries[0] {
+	if !entryEq(sorted[0], entries[2]) || !entryEq(sorted[1], entries[1]) || !entryEq(sorted[2], entries[0]) {
 		t.Errorf("sortEntries failed")
 	}
 	if dists[0] != 2 || dists[1] != 8 || dists[2] != 18 {
@@ -1060,13 +1130,17 @@ func TestSortEntries(t *testing.T) {
 }
 
 func TestNearestNeighbor(t *testing.T) {
-	things := []Spatial{
+	rects := []Rect{
 		mustRect(Point{1, 1}, []float64{1, 1}),
 		mustRect(Point{1, 3}, []float64{1, 1}),
 		mustRect(Point{3, 2}, []float64{1, 1}),
 		mustRect(Point{-7, -7}, []float64{1, 1}),
 		mustRect(Point{7, 7}, []float64{1, 1}),
 		mustRect(Point{10, 2}, []float64{1, 1}),
+	}
+	things := []Spatial{}
+	for i := range rects {
+		things = append(things, &rects[i])
 	}
 
 	for _, tc := range tests(2, 3, 3, things...) {
@@ -1089,7 +1163,7 @@ func TestGetAllBoundingBoxes(t *testing.T) {
 	rt1 := NewTree(2, 3, 3)
 	rt2 := NewTree(2, 2, 4)
 	rt3 := NewTree(2, 4, 8)
-	things := []*Rect{
+	things := []Rect{
 		mustRect(Point{0, 0}, []float64{2, 1}),
 		mustRect(Point{3, 1}, []float64{1, 2}),
 		mustRect(Point{1, 2}, []float64{2, 2}),
@@ -1158,7 +1232,7 @@ func (r byMinDist) Swap(i, j int) {
 }
 
 func TestNearestNeighborsAll(t *testing.T) {
-	things := []Spatial{
+	rects := []Rect{
 		mustRect(Point{1, 1}, []float64{1, 1}),
 		mustRect(Point{-7, -7}, []float64{1, 1}),
 		mustRect(Point{1, 3}, []float64{1, 1}),
@@ -1166,6 +1240,11 @@ func TestNearestNeighborsAll(t *testing.T) {
 		mustRect(Point{10, 2}, []float64{1, 1}),
 		mustRect(Point{3, 3}, []float64{1, 1}),
 	}
+	things := []Spatial{}
+	for i := range rects {
+		things = append(things, &rects[i])
+	}
+
 	for _, tc := range tests(2, 3, 3, things...) {
 		t.Run(tc.name, func(t *testing.T) {
 			rt := tc.build()
@@ -1195,13 +1274,17 @@ func TestNearestNeighborsAll(t *testing.T) {
 }
 
 func TestNearestNeighborsFilters(t *testing.T) {
-	things := []Spatial{
+	rects := []Rect{
 		mustRect(Point{1, 1}, []float64{1, 1}),
 		mustRect(Point{-7, -7}, []float64{1, 1}),
 		mustRect(Point{1, 3}, []float64{1, 1}),
 		mustRect(Point{7, 7}, []float64{1, 1}),
 		mustRect(Point{10, 2}, []float64{1, 1}),
 		mustRect(Point{3, 3}, []float64{1, 1}),
+	}
+	things := []Spatial{}
+	for i := range rects {
+		things = append(things, &rects[i])
 	}
 
 	expected := []Spatial{things[0], things[2], things[3]}
@@ -1229,13 +1312,17 @@ func TestNearestNeighborsFilters(t *testing.T) {
 }
 
 func TestNearestNeighborsHalf(t *testing.T) {
-	things := []Spatial{
+	rects := []Rect{
 		mustRect(Point{1, 1}, []float64{1, 1}),
 		mustRect(Point{-7, -7}, []float64{1, 1}),
 		mustRect(Point{1, 3}, []float64{1, 1}),
 		mustRect(Point{7, 7}, []float64{1, 1}),
 		mustRect(Point{10, 2}, []float64{1, 1}),
 		mustRect(Point{3, 3}, []float64{1, 1}),
+	}
+	things := []Spatial{}
+	for i := range rects {
+		things = append(things, &rects[i])
 	}
 
 	p := Point{0.5, 0.5}


### PR DESCRIPTION
This is to improve performance by avoiding garbage collection.
As shown in the pprof graphs to be uploaded in the pull request,
before this change the time spent in GC is:

runtime.mallocgc   18.19%
runtime.scanobject 25.23%

which adds up to almost half the running time.

![before](https://user-images.githubusercontent.com/765222/184542025-fd99e33e-7742-4ef9-b535-5cea1391e419.svg)
[before.pb.gz](https://github.com/dhconnelly/rtreego/files/9333550/before.pb.gz)

After this change, the time spent is:

runtime.mallocgc   7.08%
runtime.scanobject 6.40%

which is a significant reduction.

![after](https://user-images.githubusercontent.com/765222/184542042-1b37e062-2bec-4f39-bd39-36d9e1b472cf.svg)
[after.pb.gz](https://github.com/dhconnelly/rtreego/files/9333552/after.pb.gz)

This remaining time wasted in GC can be further shaved off if Point is
defined with fixed sized arrays, instead of slices.
However, fixed sized arrays run counter to the aspirations of this
library so it is not pursued here.