### PR TITLE
remove unneeeded allocation in computeBoundingBox

### DIFF
--- a/geom.go
+++ b/geom.go
@@ -343,16 +343,3 @@ func boundingBox(r1, r2 Rect) (bb Rect) {
 	}
 	return
 }
-
-// boundingBoxN constructs the smallest rectangle containing all of r...
-func boundingBoxN(rects ...Rect) (bb Rect) {
-	if len(rects) == 1 {
-		bb = rects[0]
-		return
-	}
-	bb = boundingBox(rects[0], rects[1])
-	for _, rect := range rects[2:] {
-		bb = boundingBox(bb, rect)
-	}
-	return
-}

--- a/geom_test.go
+++ b/geom_test.go
@@ -336,20 +336,6 @@ func TestBoundingBoxContains(t *testing.T) {
 	}
 }
 
-func TestBoundingBoxN(t *testing.T) {
-	rect1, _ := NewRect(Point{0, 0}, []float64{1, 1})
-	rect2, _ := NewRect(Point{0, 1}, []float64{1, 1})
-	rect3, _ := NewRect(Point{1, 0}, []float64{1, 1})
-
-	exp, _ := NewRect(Point{0, 0}, []float64{2, 2})
-	bb := boundingBoxN(rect1, rect2, rect3)
-	d1 := bb.p.dist(exp.p)
-	d2 := bb.q.dist(exp.q)
-	if d1 > EPS || d2 > EPS {
-		t.Errorf("boundingBoxN(%v, %v, %v) != %v, got %v", rect1, rect2, rect3, exp, bb)
-	}
-}
-
 func TestMinDistZero(t *testing.T) {
 	p := Point{1, 2, 3}
 	r := p.ToRect(1)

--- a/rtree.go
+++ b/rtree.go
@@ -347,11 +347,15 @@ func (n *node) getEntry() *entry {
 
 // computeBoundingBox finds the MBR of the children of n.
 func (n *node) computeBoundingBox() (bb Rect) {
-	childBoxes := make([]Rect, len(n.entries))
-	for i, e := range n.entries {
-		childBoxes[i] = e.bb
+	if len(n.entries) == 1 {
+		bb = n.entries[0].bb
+		return
 	}
-	bb = boundingBoxN(childBoxes...)
+
+	bb = boundingBox(n.entries[0].bb, n.entries[1].bb)
+	for _, e := range n.entries[2:] {
+		bb = boundingBox(bb, e.bb)
+	}
 	return
 }
 

--- a/rtree_test.go
+++ b/rtree_test.go
@@ -1159,6 +1159,24 @@ func TestNearestNeighbor(t *testing.T) {
 	}
 }
 
+func TestComputeBoundingBox(t *testing.T) {
+	rect1, _ := NewRect(Point{0, 0}, []float64{1, 1})
+	rect2, _ := NewRect(Point{0, 1}, []float64{1, 1})
+	rect3, _ := NewRect(Point{1, 0}, []float64{1, 1})
+	n := &node{}
+	n.entries = append(n.entries, entry{bb: rect1})
+	n.entries = append(n.entries, entry{bb: rect2})
+	n.entries = append(n.entries, entry{bb: rect3})
+
+	exp, _ := NewRect(Point{0, 0}, []float64{2, 2})
+	bb := n.computeBoundingBox()
+	d1 := bb.p.dist(exp.p)
+	d2 := bb.q.dist(exp.q)
+	if d1 > EPS || d2 > EPS {
+		t.Errorf("boundingBoxN(%v, %v, %v) != %v, got %v", rect1, rect2, rect3, exp, bb)
+	}
+}
+
 func TestGetAllBoundingBoxes(t *testing.T) {
 	rt1 := NewTree(2, 3, 3)
 	rt2 := NewTree(2, 2, 4)


### PR DESCRIPTION
This improves performance by reducing GC for Insert and Delete intensive
workloads.
As seen in the pprof graph to be attached in the pull request,
before this change time was spent on:

computeBoundingBox  16.26%
runtime.systemstack 20.06%

which adds up to almost 40%.

![before](https://user-images.githubusercontent.com/765222/185021452-f8eea51d-4c06-46c7-995e-de2cefbc6561.svg)

After this change, computeBoundingBox spends only 2%, and all traces of
GC are gone.
![after](https://user-images.githubusercontent.com/765222/185021481-5ae879a2-696e-4e73-a0e3-5f3adcc4ed30.svg)

