### PR TITLE
optimize condenseTree and computeBoundingBox

### DIFF
--- a/rtree.go
+++ b/rtree.go
@@ -579,10 +579,12 @@ func (tree *Rtree) findLeaf(n *node, obj Spatial, cmp Comparator) *node {
 
 // condenseTree deletes underflowing nodes and propagates the changes upwards.
 func (tree *Rtree) condenseTree(n *node) {
+	// reset the deleted buffer
 	tree.deleted = tree.deleted[:0]
 
 	for n != tree.root {
 		if len(n.entries) < tree.MinChildren {
+			// find n and delete it by swapping the last entry into its place
 			idx := -1
 			for i, e := range n.parent.entries {
 				if e.child == n {

--- a/rtree.go
+++ b/rtree.go
@@ -28,6 +28,10 @@ type Rtree struct {
 	root        *node
 	size        int
 	height      int
+
+	// deleted is a temporary buffer to avoid memory allocations in Delete.
+	// It is just an optimization and not part of the data structure.
+	deleted []*node
 }
 
 // NewTree returns an Rtree. If the number of objects given on initialization
@@ -312,10 +316,16 @@ func (tree *Rtree) adjustTree(n, nn *node) (*node, *node) {
 
 	// Re-size the bounding box of n to account for lower-level changes.
 	en := n.getEntry()
+	prevBox := en.bb
 	en.bb = n.computeBoundingBox()
 
 	// If nn is nil, then we're just propagating changes upwards.
 	if nn == nil {
+		// Optimize for the case where nothing is changed
+		// to avoid computeBoundingBox which is expensive.
+		if en.bb.Equal(prevBox) {
+			return tree.root, nil
+		}
 		return tree.adjustTree(n.parent, nil)
 	}
 
@@ -569,35 +579,45 @@ func (tree *Rtree) findLeaf(n *node, obj Spatial, cmp Comparator) *node {
 
 // condenseTree deletes underflowing nodes and propagates the changes upwards.
 func (tree *Rtree) condenseTree(n *node) {
-	deleted := []*node{}
+	tree.deleted = tree.deleted[:0]
 
 	for n != tree.root {
 		if len(n.entries) < tree.MinChildren {
-			// remove n from parent entries
-			entries := []entry{}
-			for _, e := range n.parent.entries {
-				if e.child != n {
-					entries = append(entries, e)
+			idx := -1
+			for i, e := range n.parent.entries {
+				if e.child == n {
+					idx = i
+					break
 				}
 			}
-			if len(n.parent.entries) == len(entries) {
+			if idx == -1 {
 				panic(fmt.Errorf("Failed to remove entry from parent"))
 			}
-			n.parent.entries = entries
+			l := len(n.parent.entries)
+			n.parent.entries[idx] = n.parent.entries[l-1]
+			n.parent.entries = n.parent.entries[:l-1]
 
 			// only add n to deleted if it still has children
 			if len(n.entries) > 0 {
-				deleted = append(deleted, n)
+				tree.deleted = append(tree.deleted, n)
 			}
 		} else {
 			// just a child entry deletion, no underflow
-			n.getEntry().bb = n.computeBoundingBox()
+			en := n.getEntry()
+			prevBox := en.bb
+			en.bb = n.computeBoundingBox()
+
+			if en.bb.Equal(prevBox) {
+				// Optimize for the case where nothing is changed
+				// to avoid computeBoundingBox which is expensive.
+				break
+			}
 		}
 		n = n.parent
 	}
 
-	for i := len(deleted) - 1; i >= 0; i-- {
-		n := deleted[i]
+	for i := len(tree.deleted) - 1; i >= 0; i-- {
+		n := tree.deleted[i]
 		// reinsert entry so that it will remain at the same level as before
 		e := entry{n.computeBoundingBox(), n, nil}
 		tree.insert(e, n.level+1)


### PR DESCRIPTION
condenseTree contains memory allocations that when triggered causes the
following time spent:

runtime.mheap.alloc 39.27%

![before_mheap](https://user-images.githubusercontent.com/765222/185280374-11c6b9e5-dab4-49c8-8424-ae54327ce1b9.svg)

Similarly, particular Delete heavy workloads might trigger unnecessary

computeBoundingBox 16.57%

![before_computeBoundingBox](https://user-images.githubusercontent.com/765222/185280403-58dd7394-11b4-4ff2-8e09-330ba8f21e61.svg)

This change fixes these performance issues.

![after](https://user-images.githubusercontent.com/765222/185280420-fb271840-aa42-4b16-a2d6-1b9e604a24c4.svg)

