### PR TITLE
fix:realign node struct for making it allocate less memory

### DIFF
--- a/rtree.go
+++ b/rtree.go
@@ -213,9 +213,9 @@ func (tree *Rtree) omt(level, nSlices int, objs []entry, m int) *node {
 // node represents a tree node of an Rtree.
 type node struct {
 	parent  *node
-	leaf    bool
 	entries []entry
 	level   int // node depth in the Rtree
+	leaf    bool
 }
 
 func (n *node) String() string {

--- a/rtree_test.go
+++ b/rtree_test.go
@@ -217,13 +217,13 @@ func TestChooseLeafNode(t *testing.T) {
 		rt := Rtree{}
 		rt.root = &node{}
 
-		leaf0 := &node{rt.root, true, []entry{}, 1}
+		leaf0 := &node{rt.root, []entry{}, 1, true}
 		entry0 := entry{test.bb0, leaf0, nil}
 
-		leaf1 := &node{rt.root, true, []entry{}, 1}
+		leaf1 := &node{rt.root, []entry{}, 1, true}
 		entry1 := entry{test.bb1, leaf1, nil}
 
-		leaf2 := &node{rt.root, true, []entry{}, 1}
+		leaf2 := &node{rt.root, []entry{}, 1, true}
 		entry2 := entry{test.bb2, leaf2, nil}
 
 		rt.root.entries = []entry{entry0, entry1, entry2}
@@ -359,7 +359,7 @@ func TestAdjustTreeNoPreviousSplit(t *testing.T) {
 	r01 := entry{bb: mustRect(Point{0, 1}, []float64{1, 1})}
 	r10 := entry{bb: mustRect(Point{1, 0}, []float64{1, 1})}
 	entries := []entry{r00, r01, r10}
-	n := node{rt.root, false, entries, 1}
+	n := node{rt.root, entries, 1, false}
 	rt.root.entries = []entry{{bb: Point{0, 0}.ToRect(0), child: &n}}
 
 	rt.adjustTree(&n, nil)
@@ -376,12 +376,12 @@ func TestAdjustTreeNoSplit(t *testing.T) {
 
 	r00 := entry{bb: mustRect(Point{0, 0}, []float64{1, 1})}
 	r01 := entry{bb: mustRect(Point{0, 1}, []float64{1, 1})}
-	left := node{rt.root, false, []entry{r00, r01}, 1}
+	left := node{rt.root, []entry{r00, r01}, 1, false}
 	leftEntry := entry{bb: Point{0, 0}.ToRect(0), child: &left}
 
 	r10 := entry{bb: mustRect(Point{1, 0}, []float64{1, 1})}
 	r11 := entry{bb: mustRect(Point{1, 1}, []float64{1, 1})}
-	right := node{rt.root, false, []entry{r10, r11}, 1}
+	right := node{rt.root, []entry{r10, r11}, 1, false}
 
 	rt.root.entries = []entry{leftEntry}
 	retl, retr := rt.adjustTree(&left, &right)
@@ -409,12 +409,12 @@ func TestAdjustTreeSplitParent(t *testing.T) {
 
 	r00 := entry{bb: mustRect(Point{0, 0}, []float64{1, 1})}
 	r01 := entry{bb: mustRect(Point{0, 1}, []float64{1, 1})}
-	left := node{rt.root, false, []entry{r00, r01}, 1}
+	left := node{rt.root, []entry{r00, r01}, 1, false}
 	leftEntry := entry{bb: Point{0, 0}.ToRect(0), child: &left}
 
 	r10 := entry{bb: mustRect(Point{1, 0}, []float64{1, 1})}
 	r11 := entry{bb: mustRect(Point{1, 1}, []float64{1, 1})}
-	right := node{rt.root, false, []entry{r10, r11}, 1}
+	right := node{rt.root, []entry{r10, r11}, 1, false}
 
 	rt.root.entries = []entry{leftEntry}
 	retl, retr := rt.adjustTree(&left, &right)


### PR DESCRIPTION
Reducing size of node struct by 15%